### PR TITLE
1.13 support, general refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 [![](https://jitpack.io/v/koca2000/NoteBlockAPI.svg)](https://jitpack.io/#koca2000/NoteBlockAPI)
 
 For informations about this Spigot/Bukkit API go to https://www.spigotmc.org/resources/noteblockapi.19287/
+
+Latest build (updated for 1.13) https://ci.ruinscraft.com/job/NoteBlockAPI/

--- a/README.md
+++ b/README.md
@@ -2,5 +2,3 @@
 [![](https://jitpack.io/v/koca2000/NoteBlockAPI.svg)](https://jitpack.io/#koca2000/NoteBlockAPI)
 
 For informations about this Spigot/Bukkit API go to https://www.spigotmc.org/resources/noteblockapi.19287/
-
-Latest build (updated for 1.13) https://ci.ruinscraft.com/job/NoteBlockAPI/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # NoteBlockAPI
 [![](https://jitpack.io/v/koca2000/NoteBlockAPI.svg)](https://jitpack.io/#koca2000/NoteBlockAPI)
 
-For informations about this Spigot/Bukkit API go to https://www.spigotmc.org/resources/noteblockapi.19287/
+For information about this Spigot/Bukkit API, go to https://www.spigotmc.org/resources/noteblockapi.19287/

--- a/pom.xml
+++ b/pom.xml
@@ -7,10 +7,12 @@
 	<groupId>com.xxmicloxx</groupId>
 	<artifactId>NoteBlockAPI</artifactId>
 	<version>1.2.0</version>
+	<name>NoteBlockAPI</name>
 
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+		<mainClass>com.xxmicloxx.NoteBlockAPI.NoteBlockPlayerMain</mainClass>
 	</properties>
 
 	<repositories>
@@ -80,6 +82,25 @@
 				</executions>
 			</plugin>
 		</plugins>
+		<sourceDirectory>src/main/java</sourceDirectory>
+		<defaultGoal>package</defaultGoal>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>plugin.yml</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>**/*.java</exclude>
+					<exclude>plugin.yml</exclude>
+				</excludes>
+			</resource>
+		</resources>
 	</build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,81 +1,85 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-	
-    <groupId>com.xxmicloxx</groupId>
-    <artifactId>NoteBlockAPI</artifactId>
-    <version>1.2.0</version>
-    
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.xxmicloxx</groupId>
+	<artifactId>NoteBlockAPI</artifactId>
+	<version>1.2.0</version>
+
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
-  
+
 	<repositories>
-        <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
-  			<id>bstats-repo</id>
-  			<url>http://repo.bstats.org/content/repositories/releases/</url>
+		<repository>
+			<id>spigot-repo</id>
+			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
 		</repository>
-    </repositories>
-    <dependencies>
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.12-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-  			<groupId>org.bstats</groupId>
-  			<artifactId>bstats-bukkit</artifactId>
-  			<version>1.1</version>
+		<repository>
+			<id>bstats-repo</id>
+			<url>http://repo.bstats.org/content/repositories/releases/</url>
+		</repository>
+	</repositories>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.bukkit</groupId>
+			<artifactId>bukkit</artifactId>
+			<version>1.12-R0.1-SNAPSHOT</version>
+			<scope>provided</scope>
 		</dependency>
-    </dependencies>
-    <distributionManagement>
-      <repository>
-         <id>sinndev-repo</id>
-         <name>Releases</name>
-         <url>http://repo.sinndev.com/content/repositories/releases/</url>
-      </repository>
-      <snapshotRepository>
-         <id>sinndev-repo</id>
-         <name>Snapshots</name>
-         <url>http://repo.sinndev.com/content/repositories/snapshots/</url>
-      </snapshotRepository>
-    </distributionManagement>
-    <build>
-        <plugins>
-            <plugin>
-		      <groupId>org.apache.maven.plugins</groupId>
-		      <artifactId>maven-shade-plugin</artifactId>
-		      <version>2.3</version>
-		      <configuration>
-		        <artifactSet>
-		          <includes>
-		            <include>org.bstats:*</include>
-		          </includes>
-		        </artifactSet>
-		        <relocations>
-		          <relocation>
-		            <pattern>org.bstats</pattern>
-		            <shadedPattern>com.xxmicloxx.NoteBlockAPI</shadedPattern>
-		          </relocation>
-		        </relocations>
-		      </configuration>
-		      <executions>
-		        <execution>
-		          <phase>package</phase>
-		          <goals>
-		            <goal>shade</goal>
-		          </goals>
-		        </execution>
-		      </executions>
-		    </plugin>
-        </plugins>
-    </build>
+		<dependency>
+			<groupId>org.bstats</groupId>
+			<artifactId>bstats-bukkit</artifactId>
+			<version>1.1</version>
+		</dependency>
+	</dependencies>
+
+	<distributionManagement>
+		<repository>
+			<id>sinndev-repo</id>
+			<name>Releases</name>
+			<url>http://repo.sinndev.com/content/repositories/releases/</url>
+		</repository>
+		<snapshotRepository>
+			<id>sinndev-repo</id>
+			<name>Snapshots</name>
+			<url>http://repo.sinndev.com/content/repositories/snapshots/</url>
+		</snapshotRepository>
+	</distributionManagement>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>2.3</version>
+				<configuration>
+					<artifactSet>
+						<includes>
+							<include>org.bstats:*</include>
+						</includes>
+					</artifactSet>
+					<relocations>
+						<relocation>
+							<pattern>org.bstats</pattern>
+							<shadedPattern>com.xxmicloxx.NoteBlockAPI</shadedPattern>
+						</relocation>
+					</relocations>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/CompatibilityUtils.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/CompatibilityUtils.java
@@ -76,16 +76,12 @@ public class CompatibilityUtils {
 		} catch (SecurityException e) {
 			e.printStackTrace();
 		} catch (IllegalAccessException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} catch (IllegalArgumentException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} catch (InvocationTargetException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} catch (ClassNotFoundException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
     }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/CompatibilityUtils.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/CompatibilityUtils.java
@@ -9,11 +9,20 @@ import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
+/**
+ * Fields/methods for reflection & version checking
+ *
+ */
 public class CompatibilityUtils {
 
 	public static final String OBC_DIR = Bukkit.getServer().getClass().getPackage().getName();
 	public static final String NMS_DIR = OBC_DIR.replaceFirst("org.bukkit.craftbukkit", "net.minecraft.server");
 
+	/**
+	 * Gets NMS class from given name
+	 * @param name of class (w/ package)
+	 * @return Class of given name
+	 */
 	public static Class<?> getMinecraftClass(String name) {
 		try {
 			return Class.forName(NMS_DIR + "." + name);
@@ -23,6 +32,11 @@ public class CompatibilityUtils {
 		}
 	}
 
+	/**
+	 * Gets CraftBukkit class from given name
+	 * @param name of class (w/ package)
+	 * @return Class of given name
+	 */
 	public static Class<?> getCraftBukkitClass(String name) {
 		try {
 			return Class.forName(OBC_DIR + "." + name);
@@ -32,28 +46,23 @@ public class CompatibilityUtils {
 		}
 	}
 
-	public static class NoteBlockCompatibility {
-		public static final int pre1_9 = 0;
-		public static final int pre1_12 = 1;
-		public static final int v1_12 = 2;
-		public static final int post1_12 = 3;
-		public static final int post1_13 = 4;
-	}
-
-	protected static int getCompatibility() {
-		if (Bukkit.getVersion().contains("1.8") || Bukkit.getVersion().contains("1.7")) {
-			return NoteBlockCompatibility.pre1_9;
-		} else if (Bukkit.getVersion().contains("1.9") 
-				|| Bukkit.getVersion().contains("1.10") 
-				|| Bukkit.getVersion().contains("1.11")) {
-			return NoteBlockCompatibility.pre1_12;
-		} else if (Bukkit.getVersion().contains("1.12")) {
-			return NoteBlockCompatibility.v1_12;
-		} else {
-			return NoteBlockCompatibility.post1_13;
+	/**
+	 * Returns whether the version of Bukkit is or is after 1.12
+	 * @return version is after 1.12
+	 */
+	public static boolean isPost1_12() {
+		if (!isSoundCategoryCompatible() || Bukkit.getVersion().contains("1.11")) {
+			return false;
 		}
+		return true;
 	}
 
+	/**
+	 * Returns if SoundCategory is able to be used
+	 * @see org.bukkit.SoundCategory
+	 * @see SoundCategory
+	 * @return can use SoundCategory
+	 */
 	protected static boolean isSoundCategoryCompatible() {
 		if (Bukkit.getVersion().contains("1.7") 
 				|| Bukkit.getVersion().contains("1.8") 
@@ -65,6 +74,15 @@ public class CompatibilityUtils {
 		}
 	}
 
+	/**
+	 * Plays a sound using NMS & reflection
+	 * @param player
+	 * @param location
+	 * @param sound
+	 * @param category
+	 * @param volume
+	 * @param pitch
+	 */
 	protected static void playSound(Player player, Location location, String sound, 
 			SoundCategory category, float volume, float pitch) {
 		try {
@@ -95,6 +113,15 @@ public class CompatibilityUtils {
 		}
 	}
 
+	/**
+	 * Plays a sound using NMS & reflection
+	 * @param player
+	 * @param location
+	 * @param sound
+	 * @param category
+	 * @param volume
+	 * @param pitch
+	 */
 	public static void playSound(Player player, Location location, Sound sound, 
 			SoundCategory category, float volume, float pitch) {
 		try {
@@ -125,6 +152,10 @@ public class CompatibilityUtils {
 		}
 	}
 
+	/**
+	 * Gets instruments which were added post-1.12
+	 * @return ArrayList of instruments
+	 */
 	public static ArrayList<CustomInstrument> get1_12Instruments(){
 		ArrayList<CustomInstrument> instruments = new ArrayList<>();
 		instruments.add(new CustomInstrument((byte) 0, "Guitar", "guitar.ogg"));

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/CompatibilityUtils.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/CompatibilityUtils.java
@@ -35,7 +35,9 @@ public class CompatibilityUtils {
     public static class NoteBlockCompatibility{
     	public static final int pre1_9 = 0;
     	public static final int pre1_12 = 1;
-    	public static final int post1_12 = 2;
+    	public static final int v1_12 = 2;
+    	public static final int post1_12 = 3;
+    	public static final int post1_13 = 4;
     }
     
     protected static int getCompatibility(){
@@ -43,8 +45,10 @@ public class CompatibilityUtils {
     		return NoteBlockCompatibility.pre1_9;
     	} else if (Bukkit.getVersion().contains("1.9") || Bukkit.getVersion().contains("1.10") || Bukkit.getVersion().contains("1.11")){
     		return NoteBlockCompatibility.pre1_12;
+    	} else if (Bukkit.getVersion().contains("1.12")){
+    		return NoteBlockCompatibility.v1_12;
     	} else {
-    		return NoteBlockCompatibility.post1_12;
+    		return NoteBlockCompatibility.post1_13;
     	}
     }
     

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/CompatibilityUtils.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/CompatibilityUtils.java
@@ -10,94 +10,76 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
 public class CompatibilityUtils {
-	
-	public static final String OBC_DIR = Bukkit.getServer().getClass().getPackage().getName();
-    public static final String NMS_DIR = OBC_DIR.replaceFirst("org.bukkit.craftbukkit", "net.minecraft.server");
-	
-	public static Class<?> getMinecraftClass(String name){
-        try {
-            return Class.forName(NMS_DIR + "." + name);
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
 
-    public static Class<?> getCraftBukkitClass(String name){
-        try {
-            return Class.forName(OBC_DIR + "." + name);
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-    
-    public static class NoteBlockCompatibility{
-    	public static final int pre1_9 = 0;
-    	public static final int pre1_12 = 1;
-    	public static final int v1_12 = 2;
-    	public static final int post1_12 = 3;
-    	public static final int post1_13 = 4;
-    }
-    
-    protected static int getCompatibility(){
-    	if (Bukkit.getVersion().contains("1.8") || Bukkit.getVersion().contains("1.7")){
-    		return NoteBlockCompatibility.pre1_9;
-    	} else if (Bukkit.getVersion().contains("1.9") || Bukkit.getVersion().contains("1.10") || Bukkit.getVersion().contains("1.11")){
-    		return NoteBlockCompatibility.pre1_12;
-    	} else if (Bukkit.getVersion().contains("1.12")){
-    		return NoteBlockCompatibility.v1_12;
-    	} else {
-    		return NoteBlockCompatibility.post1_13;
-    	}
-    }
-    
-    protected static boolean isSoundCategoryCompatible(){
-    	if (Bukkit.getVersion().contains("1.7") || Bukkit.getVersion().contains("1.8") || Bukkit.getVersion().contains("1.9") || Bukkit.getVersion().contains("1.10")){
-    		return false;
-    	} else {
-    		return true;
-    	}
-    }
-    
-    protected static void playSound(Player p, Location location, String sound, SoundCategory category, float volume, float pitch){
-    	try {
-    		if (isSoundCategoryCompatible()){
-				Method m = Player.class.getMethod("playSound", Location.class, String.class, Class.forName("org.bukkit.SoundCategory"), float.class, float.class);
-				Class<? extends Enum> sc = (Class<? extends Enum>) Class.forName("org.bukkit.SoundCategory");
-				Enum<?> scenum = Enum.valueOf(sc, category.name());
-				m.invoke(p, location, sound, scenum, volume, pitch);
-    		} else {
-    			Method m = Player.class.getMethod("playSound", Location.class, String.class, float.class, float.class);
-				m.invoke(p, location, sound, volume, pitch);
-    		}
-		} catch (NoSuchMethodException e) {
-			e.printStackTrace();
-		} catch (SecurityException e) {
-			e.printStackTrace();
-		} catch (IllegalAccessException e) {
-			e.printStackTrace();
-		} catch (IllegalArgumentException e) {
-			e.printStackTrace();
-		} catch (InvocationTargetException e) {
-			e.printStackTrace();
+	public static final String OBC_DIR = Bukkit.getServer().getClass().getPackage().getName();
+	public static final String NMS_DIR = OBC_DIR.replaceFirst("org.bukkit.craftbukkit", "net.minecraft.server");
+
+	public static Class<?> getMinecraftClass(String name) {
+		try {
+			return Class.forName(NMS_DIR + "." + name);
 		} catch (ClassNotFoundException e) {
 			e.printStackTrace();
+			return null;
 		}
-    }
+	}
 
-	public static void playSound(Player p, Location location, Sound sound, SoundCategory category, float volume, float pitch) {
+	public static Class<?> getCraftBukkitClass(String name) {
 		try {
-			if (isSoundCategoryCompatible()){
-				Method m = Player.class.getMethod("playSound", Location.class, Sound.class, Class.forName("org.bukkit.SoundCategory"), float.class, float.class);
-				Class<? extends Enum> sc = (Class<? extends Enum>) Class.forName("org.bukkit.SoundCategory");
-				Enum<?> scenum = Enum.valueOf(sc, category.name());
-				m.invoke(p, location, sound, scenum, volume, pitch);
+			return Class.forName(OBC_DIR + "." + name);
+		} catch (ClassNotFoundException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	public static class NoteBlockCompatibility {
+		public static final int pre1_9 = 0;
+		public static final int pre1_12 = 1;
+		public static final int v1_12 = 2;
+		public static final int post1_12 = 3;
+		public static final int post1_13 = 4;
+	}
+
+	protected static int getCompatibility() {
+		if (Bukkit.getVersion().contains("1.8") || Bukkit.getVersion().contains("1.7")) {
+			return NoteBlockCompatibility.pre1_9;
+		} else if (Bukkit.getVersion().contains("1.9") 
+				|| Bukkit.getVersion().contains("1.10") 
+				|| Bukkit.getVersion().contains("1.11")) {
+			return NoteBlockCompatibility.pre1_12;
+		} else if (Bukkit.getVersion().contains("1.12")) {
+			return NoteBlockCompatibility.v1_12;
+		} else {
+			return NoteBlockCompatibility.post1_13;
+		}
+	}
+
+	protected static boolean isSoundCategoryCompatible() {
+		if (Bukkit.getVersion().contains("1.7") 
+				|| Bukkit.getVersion().contains("1.8") 
+				|| Bukkit.getVersion().contains("1.9") 
+				|| Bukkit.getVersion().contains("1.10")) {
+			return false;
+		} else {
+			return true;
+		}
+	}
+
+	protected static void playSound(Player player, Location location, String sound, 
+			SoundCategory category, float volume, float pitch) {
+		try {
+			if (isSoundCategoryCompatible()) {
+				Method method = Player.class.getMethod("playSound", Location.class, String.class, 
+						Class.forName("org.bukkit.SoundCategory"), float.class, float.class);
+				Class<? extends Enum> soundCategory = 
+						(Class<? extends Enum>) Class.forName("org.bukkit.SoundCategory");
+				Enum<?> soundCategoryEnum = Enum.valueOf(soundCategory, category.name());
+				method.invoke(player, location, sound, soundCategoryEnum, volume, pitch);
 			} else {
-				Method m = Player.class.getMethod("playSound", Location.class, Sound.class, float.class, float.class);
-				m.invoke(p, location, sound, volume, pitch);
+				Method method = Player.class.getMethod("playSound", Location.class, 
+						String.class, float.class, float.class);
+				method.invoke(player, location, sound, volume, pitch);
 			}
-			
 		} catch (NoSuchMethodException e) {
 			e.printStackTrace();
 		} catch (SecurityException e) {
@@ -112,14 +94,45 @@ public class CompatibilityUtils {
 			e.printStackTrace();
 		}
 	}
-	
+
+	public static void playSound(Player player, Location location, Sound sound, 
+			SoundCategory category, float volume, float pitch) {
+		try {
+			if (isSoundCategoryCompatible()) {
+				Method method = Player.class.getMethod("playSound", Location.class, Sound.class, 
+						Class.forName("org.bukkit.SoundCategory"), float.class, float.class);
+				Class<? extends Enum> soundCategory = 
+						(Class<? extends Enum>) Class.forName("org.bukkit.SoundCategory");
+				Enum<?> soundCategoryEnum = Enum.valueOf(soundCategory, category.name());
+				method.invoke(player, location, sound, soundCategoryEnum, volume, pitch);
+			} else {
+				Method method = Player.class.getMethod("playSound", Location.class, 
+						Sound.class, float.class, float.class);
+				method.invoke(player, location, sound, volume, pitch);
+			}
+		} catch (NoSuchMethodException e) {
+			e.printStackTrace();
+		} catch (SecurityException e) {
+			e.printStackTrace();
+		} catch (IllegalAccessException e) {
+			e.printStackTrace();
+		} catch (IllegalArgumentException e) {
+			e.printStackTrace();
+		} catch (InvocationTargetException e) {
+			e.printStackTrace();
+		} catch (ClassNotFoundException e) {
+			e.printStackTrace();
+		}
+	}
+
 	public static ArrayList<CustomInstrument> get1_12Instruments(){
 		ArrayList<CustomInstrument> instruments = new ArrayList<>();
-		instruments.add(new CustomInstrument((byte) 0, "Guitar", "guitar.ogg", (byte) 0, (byte) 0));
-		instruments.add(new CustomInstrument((byte) 0, "Flute", "flute.ogg", (byte) 0, (byte) 0));
-		instruments.add(new CustomInstrument((byte) 0, "Bell", "bell.ogg", (byte) 0, (byte) 0));
-		instruments.add(new CustomInstrument((byte) 0, "Chime", "icechime.ogg", (byte) 0, (byte) 0));
-		instruments.add(new CustomInstrument((byte) 0, "Xylophone", "xylobone.ogg", (byte) 0, (byte) 0));
+		instruments.add(new CustomInstrument((byte) 0, "Guitar", "guitar.ogg"));
+		instruments.add(new CustomInstrument((byte) 0, "Flute", "flute.ogg"));
+		instruments.add(new CustomInstrument((byte) 0, "Bell", "bell.ogg"));
+		instruments.add(new CustomInstrument((byte) 0, "Chime", "icechime.ogg"));
+		instruments.add(new CustomInstrument((byte) 0, "Xylophone", "xylobone.ogg"));
 		return instruments;
 	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/CustomInstrument.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/CustomInstrument.java
@@ -1,5 +1,9 @@
 package com.xxmicloxx.NoteBlockAPI;
 
+/**
+ * Create custom instruments from a sound file
+ * 
+ */
 public class CustomInstrument {
 
 	private byte index;
@@ -7,7 +11,10 @@ public class CustomInstrument {
 	private String soundFileName;
 	private org.bukkit.Sound sound;
 
-	@Deprecated
+	/**
+	 * Creates a CustomInstrument
+	 * @deprecated Unused parameters
+	 */
 	public CustomInstrument(byte index, String name, String soundFileName, byte pitch, byte press) {
 		this.index = index;
 		this.name = name;
@@ -17,6 +24,12 @@ public class CustomInstrument {
 		}
 	}
 
+	/**
+	 * Creates a CustomInstrument
+	 * @param index
+	 * @param name
+	 * @param soundFileName
+	 */
 	public CustomInstrument(byte index, String name, String soundFileName) {
 		this.index = index;
 		this.name = name;
@@ -26,23 +39,43 @@ public class CustomInstrument {
 		}
 	}
 
+	/**
+	 * Gets index of CustomInstrument
+	 * @return index
+	 */
 	public byte getIndex() {
 		return index;
 	}
 
+	/**
+	 * Gets name of CustomInstrument
+	 * @return name
+	 */
 	public String getName() {
 		return name;
 	}
 
+	/**
+	 * Gets file name of the sound
+	 * @deprecated misleading name
+	 */
 	@Deprecated
 	public String getSoundfile() {
 		return getSoundFileName();
 	}
 
+	/**
+	 * Gets file name of the sound
+	 * @return file name
+	 */
 	public String getSoundFileName() {
 		return soundFileName;
 	}
 
+	/**
+	 * Gets the Sound enum for this CustomInstrument
+	 * @return
+	 */
 	public org.bukkit.Sound getSound() {
 		return sound;
 	}

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/CustomInstrument.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/CustomInstrument.java
@@ -23,8 +23,11 @@ public class CustomInstrument {
 					this.sound = Sound.valueOf("NOTE_PLING");
 					break;
 				case CompatibilityUtils.NoteBlockCompatibility.pre1_12:
-				case NoteBlockCompatibility.post1_12:
+				case NoteBlockCompatibility.v1_12:
 					this.sound = Sound.valueOf("BLOCK_NOTE_PLING");
+					break;
+				case NoteBlockCompatibility.post1_13:
+					this.sound = Sound.valueOf("BLOCK_NOTE_BLOCK_PLING");
 					break;
 			}
 		}

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/CustomInstrument.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/CustomInstrument.java
@@ -1,9 +1,5 @@
 package com.xxmicloxx.NoteBlockAPI;
 
-import org.bukkit.Sound;
-
-import com.xxmicloxx.NoteBlockAPI.CompatibilityUtils.NoteBlockCompatibility;
-
 public class CustomInstrument {
 	
 	private byte index;
@@ -11,25 +7,14 @@ public class CustomInstrument {
 	private String soundfile;
 	private byte pitch;
 	private byte press;
-	private Sound sound;
+	private org.bukkit.Sound sound;
 	
 	public CustomInstrument(byte index, String name, String soundfile, byte pitch, byte press){
 		this.index = index;
 		this.name = name;
 		this.soundfile = soundfile.replaceAll(".ogg", "");
 		if (this.soundfile.equalsIgnoreCase("pling")){
-			switch (CompatibilityUtils.getCompatibility()){
-				case NoteBlockCompatibility.pre1_9:
-					this.sound = Sound.valueOf("NOTE_PLING");
-					break;
-				case CompatibilityUtils.NoteBlockCompatibility.pre1_12:
-				case NoteBlockCompatibility.v1_12:
-					this.sound = Sound.valueOf("BLOCK_NOTE_PLING");
-					break;
-				case NoteBlockCompatibility.post1_13:
-					this.sound = Sound.valueOf("BLOCK_NOTE_BLOCK_PLING");
-					break;
-			}
+			this.sound = Sound.getFromBukkitName("BLOCK_NOTE_PLING");
 		}
 		this.pitch = pitch;
 		this.press = press;
@@ -47,7 +32,7 @@ public class CustomInstrument {
 		return soundfile;
 	}
 	
-	public Sound getSound(){
+	public org.bukkit.Sound getSound() {
 		return sound;
 	}
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/CustomInstrument.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/CustomInstrument.java
@@ -15,6 +15,7 @@ public class CustomInstrument {
 	 * Creates a CustomInstrument
 	 * @deprecated Unused parameters
 	 */
+	@Deprecated
 	public CustomInstrument(byte index, String name, String soundFileName, byte pitch, byte press) {
 		this.index = index;
 		this.name = name;
@@ -73,8 +74,8 @@ public class CustomInstrument {
 	}
 
 	/**
-	 * Gets the Sound enum for this CustomInstrument
-	 * @return
+	 * Gets the org.bukkit.Sound enum for this CustomInstrument
+	 * @return org.bukkit.Sound enum
 	 */
 	public org.bukkit.Sound getSound() {
 		return sound;

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/CustomInstrument.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/CustomInstrument.java
@@ -1,23 +1,29 @@
 package com.xxmicloxx.NoteBlockAPI;
 
 public class CustomInstrument {
-	
+
 	private byte index;
 	private String name;
-	private String soundfile;
-	private byte pitch;
-	private byte press;
+	private String soundFileName;
 	private org.bukkit.Sound sound;
-	
-	public CustomInstrument(byte index, String name, String soundfile, byte pitch, byte press){
+
+	@Deprecated
+	public CustomInstrument(byte index, String name, String soundFileName, byte pitch, byte press) {
 		this.index = index;
 		this.name = name;
-		this.soundfile = soundfile.replaceAll(".ogg", "");
-		if (this.soundfile.equalsIgnoreCase("pling")){
+		this.soundFileName = soundFileName.replaceAll(".ogg", "");
+		if (this.soundFileName.equalsIgnoreCase("pling")){
 			this.sound = Sound.getFromBukkitName("BLOCK_NOTE_PLING");
 		}
-		this.pitch = pitch;
-		this.press = press;
+	}
+
+	public CustomInstrument(byte index, String name, String soundFileName) {
+		this.index = index;
+		this.name = name;
+		this.soundFileName = soundFileName.replaceAll(".ogg", "");
+		if (this.soundFileName.equalsIgnoreCase("pling")){
+			this.sound = Sound.getFromBukkitName("BLOCK_NOTE_PLING");
+		}
 	}
 
 	public byte getIndex() {
@@ -28,11 +34,17 @@ public class CustomInstrument {
 		return name;
 	}
 
+	@Deprecated
 	public String getSoundfile() {
-		return soundfile;
+		return getSoundFileName();
 	}
-	
+
+	public String getSoundFileName() {
+		return soundFileName;
+	}
+
 	public org.bukkit.Sound getSound() {
 		return sound;
 	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/FadeType.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/FadeType.java
@@ -1,5 +1,7 @@
 package com.xxmicloxx.NoteBlockAPI;
 
 public enum FadeType {
-    FADE_LINEAR
+
+	FADE_LINEAR
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Instrument.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Instrument.java
@@ -4,83 +4,84 @@ import com.xxmicloxx.NoteBlockAPI.CompatibilityUtils.NoteBlockCompatibility;
 
 public class Instrument {
 
-    public static org.bukkit.Sound getInstrument(byte instrument) {
-	    return org.bukkit.Sound.valueOf(getInstrumentName(instrument));
-    }
+	public static org.bukkit.Sound getInstrument(byte instrument) {
+		return org.bukkit.Sound.valueOf(getInstrumentName(instrument));
+	}
 
-    public static String getInstrumentName(byte instrument) {
-    	switch (instrument) {
-		    case 0:
-	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_HARP").name();
-	        case 1:
-	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_BASS").name();
-	        case 2:
-	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_BASEDRUM").name();
-	        case 3:
-	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_SNARE").name();
-	        case 4:
-	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_HAT").name();
-	        case 5:
-	    	    return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_GUITAR").name();
-	        case 6:
-	    	    return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_FLUTE").name();
-	        case 7:
-	    	    return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_BELL").name();
-	        case 8:
-	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_CHIME").name();
-	        case 9:
-	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_XYLOPHONE").name();
-	        default:
-	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_HARP").name();
-	    }
-    }
+	public static String getInstrumentName(byte instrument) {
+		switch (instrument) {
+			case 0:
+				return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_HARP").name();
+			case 1:
+				return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_BASS").name();
+			case 2:
+				return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_BASEDRUM").name();
+			case 3:
+				return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_SNARE").name();
+			case 4:
+				return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_HAT").name();
+			case 5:
+				return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_GUITAR").name();
+			case 6:
+				return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_FLUTE").name();
+			case 7:
+				return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_BELL").name();
+			case 8:
+				return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_CHIME").name();
+			case 9:
+				return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_XYLOPHONE").name();
+			default:
+				return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_HARP").name();
+		}
+	}
 
-    public static org.bukkit.Instrument getBukkitInstrument(byte instrument) {
-        switch (instrument) {
-            case 0:
-                return org.bukkit.Instrument.PIANO;
-            case 1:
-                return org.bukkit.Instrument.BASS_GUITAR;
-            case 2:
-                return org.bukkit.Instrument.BASS_DRUM;
-            case 3:
-                return org.bukkit.Instrument.SNARE_DRUM;
-            case 4:
-                return org.bukkit.Instrument.STICKS;
-            case 5:
-                return org.bukkit.Instrument.GUITAR;
-            case 6:
-            	return org.bukkit.Instrument.FLUTE;
-            case 7:
-            	return org.bukkit.Instrument.BELL;
-            case 8:
-            	return org.bukkit.Instrument.CHIME;
-            case 9:
-            	return org.bukkit.Instrument.XYLOPHONE;
-            default:
-                return org.bukkit.Instrument.PIANO;
-        }
-    }
-    
-    public static boolean isCustomInstrument(byte instrument){
-    	if (CompatibilityUtils.getCompatibility() != NoteBlockCompatibility.post1_12){
-    		if (instrument > 4){
-    			return true;
-    		}
-    		return false;
-    	} else {
-    		if (instrument > 9){
-    			return true;
-    		}
-    		return false;
-    	}
-    }
-    
-    public static byte getCustomInstrumentFirstIndex(){
-    	if (CompatibilityUtils.getCompatibility() != NoteBlockCompatibility.post1_12){
-    		return 5;
-    	} else {
-    		return 10;
-    	}
-    }
+	public static org.bukkit.Instrument getBukkitInstrument(byte instrument) {
+		switch (instrument) {
+			case 0:
+				return org.bukkit.Instrument.PIANO;
+			case 1:
+				return org.bukkit.Instrument.BASS_GUITAR;
+			case 2:
+				return org.bukkit.Instrument.BASS_DRUM;
+			case 3:
+				return org.bukkit.Instrument.SNARE_DRUM;
+			case 4:
+				return org.bukkit.Instrument.STICKS;
+			case 5:
+				return org.bukkit.Instrument.GUITAR;
+			case 6:
+				return org.bukkit.Instrument.FLUTE;
+			case 7:
+				return org.bukkit.Instrument.BELL;
+			case 8:
+				return org.bukkit.Instrument.CHIME;
+			case 9:
+				return org.bukkit.Instrument.XYLOPHONE;
+			default:
+				return org.bukkit.Instrument.PIANO;
+		}
+	}
+
+	public static boolean isCustomInstrument(byte instrument) {
+		if (CompatibilityUtils.getCompatibility() != NoteBlockCompatibility.post1_12) {
+			if (instrument > 4) {
+				return true;
+			}
+			return false;
+		} else {
+			if (instrument > 9) {
+				return true;
+			}
+			return false;
+		}
+	}
+
+	public static byte getCustomInstrumentFirstIndex() {
+		if (CompatibilityUtils.getCompatibility() != NoteBlockCompatibility.post1_12) {
+			return 5;
+		} else {
+			return 10;
+		}
+	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Instrument.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Instrument.java
@@ -4,6 +4,7 @@ package com.xxmicloxx.NoteBlockAPI;
  * Various methods for working with instruments
  * @deprecated Moved to InstrumentUtils
  */
+@Deprecated
 public class Instrument {
 
 	/**
@@ -66,25 +67,30 @@ public class Instrument {
 				return org.bukkit.Instrument.SNARE_DRUM;
 			case 4:
 				return org.bukkit.Instrument.STICKS;
-			case 5:
-				return org.bukkit.Instrument.GUITAR;
-			case 6:
-				return org.bukkit.Instrument.FLUTE;
-			case 7:
-				return org.bukkit.Instrument.BELL;
-			case 8:
-				return org.bukkit.Instrument.CHIME;
-			case 9:
-				return org.bukkit.Instrument.XYLOPHONE;
-			default:
+			default: {
+				if (CompatibilityUtils.isPost1_12()) {
+					switch (instrument) {
+						case 5:
+							return org.bukkit.Instrument.GUITAR;
+						case 6:
+							return org.bukkit.Instrument.FLUTE;
+						case 7:
+							return org.bukkit.Instrument.BELL;
+						case 8:
+							return org.bukkit.Instrument.CHIME;
+						case 9:
+							return org.bukkit.Instrument.XYLOPHONE;
+					}
+				}
 				return org.bukkit.Instrument.PIANO;
+			}
 		}
 	}
 
 	/**
 	 * If true, the byte given represents a custom instrument
 	 * @param instrument
-	 * @return
+	 * @return whether the byte represents a custom instrument
 	 */
 	public static boolean isCustomInstrument(byte instrument) {
 		if (CompatibilityUtils.isPost1_12()) {
@@ -102,7 +108,7 @@ public class Instrument {
 	/**
 	 * Gets the first index in which a custom instrument 
 	 * can be added to the existing list of instruments
-	 * @return instrument as a byte
+	 * @return index where an instrument can be added
 	 */
 	public static byte getCustomInstrumentFirstIndex() {
 		if (CompatibilityUtils.isPost1_12()) {

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Instrument.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Instrument.java
@@ -1,83 +1,38 @@
 package com.xxmicloxx.NoteBlockAPI;
 
-import org.bukkit.Sound;
-
 import com.xxmicloxx.NoteBlockAPI.CompatibilityUtils.NoteBlockCompatibility;
 
 public class Instrument {
 
-    public static Sound getInstrument(byte instrument) {
-    	if (CompatibilityUtils.getCompatibility() == NoteBlockCompatibility.pre1_9){
-			switch (instrument) {
-        		case 0:
-                    return Sound.valueOf("NOTE_PIANO");
-                case 1:
-                    return Sound.valueOf("NOTE_BASS_GUITAR");
-                case 2:
-                    return Sound.valueOf("NOTE_BASS_DRUM");
-                case 3:
-                    return Sound.valueOf("NOTE_SNARE_DRUM");
-                case 4:
-                    return Sound.valueOf("NOTE_STICKS");
-                default:
-                    return Sound.valueOf("NOTE_PIANO");
-    		}
+    public static org.bukkit.Sound getInstrument(byte instrument) {
+	    return org.bukkit.Sound.valueOf(getInstrumentName(instrument));
+    }
 
-    	} else if (CompatibilityUtils.getCompatibility() == NoteBlockCompatibility.pre1_12 || 
-    			CompatibilityUtils.getCompatibility() == NoteBlockCompatibility.v1_12){
-			switch (instrument) {
-	            case 0:
-	                return Sound.valueOf("BLOCK_NOTE_HARP");
-	            case 1:
-	                return Sound.valueOf("BLOCK_NOTE_BASS");
-	            case 2:
-	                return Sound.valueOf("BLOCK_NOTE_BASEDRUM");
-	            case 3:
-	                return Sound.valueOf("BLOCK_NOTE_SNARE");
-	            case 4:
-	                return Sound.valueOf("BLOCK_NOTE_HAT");
-			}
-			if (CompatibilityUtils.getCompatibility() == NoteBlockCompatibility.v1_12){
-				switch (instrument) {
-		            case 5:
-		            	return Sound.valueOf("BLOCK_NOTE_GUITAR");
-		            case 6:
-		            	return Sound.valueOf("BLOCK_NOTE_FLUTE");
-		            case 7:
-		            	return Sound.valueOf("BLOCK_NOTE_BELL");
-		            case 8:
-		                return Sound.valueOf("BLOCK_NOTE_CHIME");
-		            case 9:
-		                return Sound.valueOf("BLOCK_NOTE_XYLOPHONE");
-				}
-			}
-
-    	} else if (CompatibilityUtils.getCompatibility() == NoteBlockCompatibility.post1_13) {
-    		switch (instrument) {
-    		    case 0:
-                    return Sound.valueOf("BLOCK_NOTE_BLOCK_HARP");
-                case 1:
-                    return Sound.valueOf("BLOCK_NOTE_BLOCK_BASS");
-                case 2:
-                    return Sound.valueOf("BLOCK_NOTE_BLOCK_BASEDRUM");
-                case 3:
-                    return Sound.valueOf("BLOCK_NOTE_BLOCK_SNARE");
-                case 4:
-                    return Sound.valueOf("BLOCK_NOTE_BLOCK_HAT");
-                case 5:
-            	    return Sound.valueOf("BLOCK_NOTE_BLOCK_GUITAR");
-                case 6:
-            	    return Sound.valueOf("BLOCK_NOTE_BLOCK_FLUTE");
-                case 7:
-            	    return Sound.valueOf("BLOCK_NOTE_BLOCK_BELL");
-                case 8:
-                    return Sound.valueOf("BLOCK_NOTE_BLOCK_CHIME");
-                case 9:
-                    return Sound.valueOf("BLOCK_NOTE_BLOCK_XYLOPHONE");
-    	    }
-    	}
-
-    	return Sound.valueOf("BLOCK_NOTE_BLOCK_HARP");
+    public static String getInstrumentName(byte instrument) {
+    	switch (instrument) {
+		    case 0:
+	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_HARP").name();
+	        case 1:
+	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_BASS").name();
+	        case 2:
+	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_BASEDRUM").name();
+	        case 3:
+	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_SNARE").name();
+	        case 4:
+	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_HAT").name();
+	        case 5:
+	    	    return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_GUITAR").name();
+	        case 6:
+	    	    return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_FLUTE").name();
+	        case 7:
+	    	    return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_BELL").name();
+	        case 8:
+	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_CHIME").name();
+	        case 9:
+	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_XYLOPHONE").name();
+	        default:
+	            return Sound.getFromBukkitName("BLOCK_NOTE_BLOCK_HARP").name();
+	    }
     }
 
     public static org.bukkit.Instrument getBukkitInstrument(byte instrument) {
@@ -92,6 +47,16 @@ public class Instrument {
                 return org.bukkit.Instrument.SNARE_DRUM;
             case 4:
                 return org.bukkit.Instrument.STICKS;
+            case 5:
+                return org.bukkit.Instrument.GUITAR;
+            case 6:
+            	return org.bukkit.Instrument.FLUTE;
+            case 7:
+            	return org.bukkit.Instrument.BELL;
+            case 8:
+            	return org.bukkit.Instrument.CHIME;
+            case 9:
+            	return org.bukkit.Instrument.XYLOPHONE;
             default:
                 return org.bukkit.Instrument.PIANO;
         }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Instrument.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Instrument.java
@@ -22,7 +22,9 @@ public class Instrument {
                 default:
                     return Sound.valueOf("NOTE_PIANO");
     		}
-    	} else {
+
+    	} else if (CompatibilityUtils.getCompatibility() == NoteBlockCompatibility.pre1_12 || 
+    			CompatibilityUtils.getCompatibility() == NoteBlockCompatibility.v1_12){
 			switch (instrument) {
 	            case 0:
 	                return Sound.valueOf("BLOCK_NOTE_HARP");
@@ -35,8 +37,7 @@ public class Instrument {
 	            case 4:
 	                return Sound.valueOf("BLOCK_NOTE_HAT");
 			}
-			
-			if (CompatibilityUtils.getCompatibility() == NoteBlockCompatibility.post1_12){
+			if (CompatibilityUtils.getCompatibility() == NoteBlockCompatibility.v1_12){
 				switch (instrument) {
 		            case 5:
 		            	return Sound.valueOf("BLOCK_NOTE_GUITAR");
@@ -50,10 +51,33 @@ public class Instrument {
 		                return Sound.valueOf("BLOCK_NOTE_XYLOPHONE");
 				}
 			}
-			
-			return Sound.valueOf("BLOCK_NOTE_HARP");
-			
+
+    	} else if (CompatibilityUtils.getCompatibility() == NoteBlockCompatibility.post1_13) {
+    		switch (instrument) {
+    		    case 0:
+                    return Sound.valueOf("BLOCK_NOTE_BLOCK_HARP");
+                case 1:
+                    return Sound.valueOf("BLOCK_NOTE_BLOCK_BASS");
+                case 2:
+                    return Sound.valueOf("BLOCK_NOTE_BLOCK_BASEDRUM");
+                case 3:
+                    return Sound.valueOf("BLOCK_NOTE_BLOCK_SNARE");
+                case 4:
+                    return Sound.valueOf("BLOCK_NOTE_BLOCK_HAT");
+                case 5:
+            	    return Sound.valueOf("BLOCK_NOTE_BLOCK_GUITAR");
+                case 6:
+            	    return Sound.valueOf("BLOCK_NOTE_BLOCK_FLUTE");
+                case 7:
+            	    return Sound.valueOf("BLOCK_NOTE_BLOCK_BELL");
+                case 8:
+                    return Sound.valueOf("BLOCK_NOTE_BLOCK_CHIME");
+                case 9:
+                    return Sound.valueOf("BLOCK_NOTE_BLOCK_XYLOPHONE");
+    	    }
     	}
+
+    	return Sound.valueOf("BLOCK_NOTE_BLOCK_HARP");
     }
 
     public static org.bukkit.Instrument getBukkitInstrument(byte instrument) {

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/InstrumentUtils.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/InstrumentUtils.java
@@ -65,25 +65,30 @@ public class InstrumentUtils {
 				return org.bukkit.Instrument.SNARE_DRUM;
 			case 4:
 				return org.bukkit.Instrument.STICKS;
-			case 5:
-				return org.bukkit.Instrument.GUITAR;
-			case 6:
-				return org.bukkit.Instrument.FLUTE;
-			case 7:
-				return org.bukkit.Instrument.BELL;
-			case 8:
-				return org.bukkit.Instrument.CHIME;
-			case 9:
-				return org.bukkit.Instrument.XYLOPHONE;
-			default:
+			default: {
+				if (CompatibilityUtils.isPost1_12()) {
+					switch (instrument) {
+						case 5:
+							return org.bukkit.Instrument.GUITAR;
+						case 6:
+							return org.bukkit.Instrument.FLUTE;
+						case 7:
+							return org.bukkit.Instrument.BELL;
+						case 8:
+							return org.bukkit.Instrument.CHIME;
+						case 9:
+							return org.bukkit.Instrument.XYLOPHONE;
+					}
+				}
 				return org.bukkit.Instrument.PIANO;
+			}
 		}
 	}
 
 	/**
 	 * If true, the byte given represents a custom instrument
 	 * @param instrument
-	 * @return
+	 * @return whether the byte represents a custom instrument
 	 */
 	public static boolean isCustomInstrument(byte instrument) {
 		if (CompatibilityUtils.isPost1_12()) {
@@ -101,7 +106,7 @@ public class InstrumentUtils {
 	/**
 	 * Gets the first index in which a custom instrument 
 	 * can be added to the existing list of instruments
-	 * @return instrument as a byte
+	 * @return index where an instrument can be added
 	 */
 	public static byte getCustomInstrumentFirstIndex() {
 		if (CompatibilityUtils.isPost1_12()) {

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/InstrumentUtils.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/InstrumentUtils.java
@@ -2,9 +2,8 @@ package com.xxmicloxx.NoteBlockAPI;
 
 /**
  * Various methods for working with instruments
- * @deprecated Moved to InstrumentUtils
  */
-public class Instrument {
+public class InstrumentUtils {
 
 	/**
 	 * Returns the org.bukkit.Sound enum for the current server version

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Interpolator.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Interpolator.java
@@ -22,80 +22,82 @@ import java.util.Arrays;
  */
 public class Interpolator {
 
-    public static double[] interpLinear(double[] x, double[] y, double[] xi) throws IllegalArgumentException {
+	public static double[] interpLinear(double[] x, double[] y, double[] xi) throws IllegalArgumentException {
+		if (x.length != y.length) {
+			throw new IllegalArgumentException("X and Y must be the same length");
+		}
+		if (x.length == 1) {
+			throw new IllegalArgumentException("X must contain more than one value");
+		}
 
-        if (x.length != y.length) {
-            throw new IllegalArgumentException("X and Y must be the same length");
-        }
-        if (x.length == 1) {
-            throw new IllegalArgumentException("X must contain more than one value");
-        }
-        double[] dx = new double[x.length - 1];
-        double[] dy = new double[x.length - 1];
-        double[] slope = new double[x.length - 1];
-        double[] intercept = new double[x.length - 1];
+		double[] dx = new double[x.length - 1];
+		double[] dy = new double[x.length - 1];
+		double[] slope = new double[x.length - 1];
+		double[] intercept = new double[x.length - 1];
 
-        // Calculate the line equation (i.e. slope and intercept) between each point
-        for (int i = 0; i < x.length - 1; i++) {
-            dx[i] = x[i + 1] - x[i];
-            if (dx[i] == 0) {
-                throw new IllegalArgumentException("X must be montotonic. A duplicate " + "x-value was found");
-            }
-            if (dx[i] < 0) {
-                throw new IllegalArgumentException("X must be sorted");
-            }
-            dy[i] = y[i + 1] - y[i];
-            slope[i] = dy[i] / dx[i];
-            intercept[i] = y[i] - x[i] * slope[i];
-        }
+		// Calculate the line equation (i.e. slope and intercept) between each point
+		for (int i = 0; i < x.length - 1; i++) {
+			dx[i] = x[i + 1] - x[i];
+			if (dx[i] == 0) {
+				throw new IllegalArgumentException("X must be montotonic. A duplicate " + "x-value was found");
+			}
+			if (dx[i] < 0) {
+				throw new IllegalArgumentException("X must be sorted");
+			}
+			dy[i] = y[i + 1] - y[i];
+			slope[i] = dy[i] / dx[i];
+			intercept[i] = y[i] - x[i] * slope[i];
+		}
 
-        // Perform the interpolation here
-        double[] yi = new double[xi.length];
-        for (int i = 0; i < xi.length; i++) {
-            if ((xi[i] > x[x.length - 1]) || (xi[i] < x[0])) {
-                yi[i] = Double.NaN;
-            } else {
-                int loc = Arrays.binarySearch(x, xi[i]);
-                if (loc < -1) {
-                    loc = -loc - 2;
-                    yi[i] = slope[loc] * xi[i] + intercept[loc];
-                } else {
-                    yi[i] = y[loc];
-                }
-            }
-        }
+		// Perform the interpolation here
+		double[] yi = new double[xi.length];
+		for (int i = 0; i < xi.length; i++) {
+			if ((xi[i] > x[x.length - 1]) || (xi[i] < x[0])) {
+				yi[i] = Double.NaN;
+			} else {
+				int loc = Arrays.binarySearch(x, xi[i]);
+				if (loc < -1) {
+					loc = -loc - 2;
+					yi[i] = slope[loc] * xi[i] + intercept[loc];
+				} else {
+					yi[i] = y[loc];
+				}
+			}
+		}
 
-        return yi;
-    }
+		return yi;
+	}
 
-    public static double[] interpLinear(long[] x, double[] y, long[] xi) throws IllegalArgumentException {
+	public static double[] interpLinear(long[] x, double[] y, long[] xi) throws IllegalArgumentException {
+		double[] xd = new double[x.length];
+		for (int i = 0; i < x.length; i++) {
+			xd[i] = (double) x[i];
+		}
 
-        double[] xd = new double[x.length];
-        for (int i = 0; i < x.length; i++) {
-            xd[i] = (double) x[i];
-        }
+		double[] xid = new double[xi.length];
+		for (int i = 0; i < xi.length; i++) {
+			xid[i] = (double) xi[i];
+		}
 
-        double[] xid = new double[xi.length];
-        for (int i = 0; i < xi.length; i++) {
-            xid[i] = (double) xi[i];
-        }
+		return interpLinear(xd, y, xid);
+	}
 
-        return interpLinear(xd, y, xid);
-    }
+	public static double interpLinear(double[] xy, double xx) {
+		if (xy.length % 2 != 0) {
+			throw new IllegalArgumentException("XY must be divisible by two.");
+		}
 
-    public static double interpLinear(double[] xy, double xx) {
-        if (xy.length % 2 != 0) {
-            throw new IllegalArgumentException("XY must be divisible by two.");
-        }
-        double[] x = new double[xy.length/2];
-        double[] y = new double[x.length];
-        for (int i = 0; i < xy.length; i++) {
-            if (i % 2 == 0) {
-                x[i/2] = xy[i];
-            } else {
-                y[i/2] = xy[i];
-            }
-        }
-        return interpLinear(x, y, new double[] {xx})[0];
-    }
+		double[] x = new double[xy.length/2];
+		double[] y = new double[x.length];
+
+		for (int i = 0; i < xy.length; i++) {
+			if (i % 2 == 0) {
+				x[i/2] = xy[i];
+			} else {
+				y[i/2] = xy[i];
+			}
+		}
+		return interpLinear(x, y, new double[] {xx})[0];
+	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Layer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Layer.java
@@ -4,39 +4,40 @@ import java.util.HashMap;
 
 public class Layer {
 
-    private HashMap<Integer, Note> hashMap = new HashMap<Integer, Note>();
-    private byte volume = 100;
-    private String name = "";
+	private HashMap<Integer, Note> hashMap = new HashMap<Integer, Note>();
+	private byte volume = 100;
+	private String name = "";
 
-    public HashMap<Integer, Note> getHashMap() {
-        return hashMap;
-    }
+	public HashMap<Integer, Note> getHashMap() {
+		return hashMap;
+	}
 
-    public void setHashMap(HashMap<Integer, Note> hashMap) {
-        this.hashMap = hashMap;
-    }
+	public void setHashMap(HashMap<Integer, Note> hashMap) {
+		this.hashMap = hashMap;
+	}
 
-    public String getName() {
-        return name;
-    }
+	public String getName() {
+		return name;
+	}
 
-    public void setName(String name) {
-        this.name = name;
-    }
+	public void setName(String name) {
+		this.name = name;
+	}
 
-    public Note getNote(int tick) {
-        return hashMap.get(tick);
-    }
+	public Note getNote(int tick) {
+		return hashMap.get(tick);
+	}
 
-    public void setNote(int tick, Note note) {
-        hashMap.put(tick, note);
-    }
+	public void setNote(int tick, Note note) {
+		hashMap.put(tick, note);
+	}
 
-    public byte getVolume() {
-        return volume;
-    }
+	public byte getVolume() {
+		return volume;
+	}
 
-    public void setVolume(byte volume) {
-        this.volume = volume;
-    }
+	public void setVolume(byte volume) {
+		this.volume = volume;
+	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Layer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Layer.java
@@ -18,6 +18,7 @@ public class Layer {
 	 * @return HashMap of notes with the tick they are played at
 	 * @Deprecated Method name is vague
 	 */
+	@Deprecated
 	public HashMap<Integer, Note> getHashMap() {
 		return getNotesAtTicks();
 	}
@@ -26,6 +27,7 @@ public class Layer {
 	 * Sets the notes in the Layer with the tick they are created as a hash map
 	 * @Deprecated Method name is vague
 	 */
+	@Deprecated
 	public void setHashMap(HashMap<Integer, Note> hashMap) {
 		setNotesAtTicks(hashMap);
 	}
@@ -40,7 +42,6 @@ public class Layer {
 
 	/**
 	 * Sets the notes in the Layer with the tick they are created as a hash map
-	 * @Deprecated Method name is vague
 	 */
 	public void setNotesAtTicks(HashMap<Integer, Note> notesAtTicks) {
 		this.notesAtTicks = notesAtTicks;

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Layer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Layer.java
@@ -2,40 +2,90 @@ package com.xxmicloxx.NoteBlockAPI;
 
 import java.util.HashMap;
 
+/**
+ * Represents a series of notes in Note Block Studio. 
+ * A Layer can have a maximum of one note per tick (20 ticks a second)
+ *
+ */
 public class Layer {
 
-	private HashMap<Integer, Note> hashMap = new HashMap<Integer, Note>();
+	private HashMap<Integer, Note> notesAtTicks = new HashMap<Integer, Note>();
 	private byte volume = 100;
 	private String name = "";
 
+	/**
+	 * Gets the notes in the Layer with the tick they are created as a hash map. 
+	 * @return HashMap of notes with the tick they are played at
+	 * @Deprecated Method name is vague
+	 */
 	public HashMap<Integer, Note> getHashMap() {
-		return hashMap;
+		return getNotesAtTicks();
 	}
 
+	/**
+	 * Sets the notes in the Layer with the tick they are created as a hash map
+	 * @Deprecated Method name is vague
+	 */
 	public void setHashMap(HashMap<Integer, Note> hashMap) {
-		this.hashMap = hashMap;
+		setNotesAtTicks(hashMap);
 	}
 
+	/**
+	 * Gets the notes in the Layer with the tick they are created as a hash map
+	 * @return HashMap of notes with the tick they are played at
+	 */
+	public HashMap<Integer, Note> getNotesAtTicks() {
+		return notesAtTicks;
+	}
+
+	/**
+	 * Sets the notes in the Layer with the tick they are created as a hash map
+	 * @Deprecated Method name is vague
+	 */
+	public void setNotesAtTicks(HashMap<Integer, Note> notesAtTicks) {
+		this.notesAtTicks = notesAtTicks;
+	}
+
+	/**
+	 * Gets the name of the Layer
+	 */
 	public String getName() {
 		return name;
 	}
 
+	/**
+	 * Sets the name of the Layer
+	 */
 	public void setName(String name) {
 		this.name = name;
 	}
 
+	/**
+	 * Gets the note played at a given tick
+	 */
 	public Note getNote(int tick) {
-		return hashMap.get(tick);
+		return notesAtTicks.get(tick);
 	}
 
+	/**
+	 * Sets the given note at the given tick in the Layer
+	 */
 	public void setNote(int tick, Note note) {
-		hashMap.put(tick, note);
+		notesAtTicks.put(tick, note);
 	}
 
+	/**
+	 * Gets the volume of all notes in the Layer
+	 * @return byte representing the volume
+	 */
 	public byte getVolume() {
 		return volume;
 	}
 
+	/**
+	 * Sets the volume for all notes in the Layer
+	 * @param volume
+	 */
 	public void setVolume(byte volume) {
 		this.volume = volume;
 	}

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/NBSDecoder.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/NBSDecoder.java
@@ -99,37 +99,37 @@ public class NBSDecoder {
 				}
 			}
 			for (int i = 0; i < songHeight; i++) {
-				Layer l = layerHashMap.get(i);
+				Layer layer = layerHashMap.get(i);
 
 				String name = readString(dataInputStream);
 				byte volume = dataInputStream.readByte();
-				if (l != null) {
-					l.setName(name);
-					l.setVolume(volume);
+				if (layer != null) {
+					layer.setName(name);
+					layer.setVolume(volume);
 				}
 			}
 			//count of custom instruments
-			byte custom = dataInputStream.readByte();
-			CustomInstrument[] customInstruments = new CustomInstrument[custom];
+			byte customAmnt = dataInputStream.readByte();
+			CustomInstrument[] customInstrumentsArray = new CustomInstrument[customAmnt];
 
-			for (int index = 0; index < custom; index++) {
-				customInstruments[index] = new CustomInstrument((byte) index, 
+			for (int index = 0; index < customAmnt; index++) {
+				customInstrumentsArray[index] = new CustomInstrument((byte) index, 
 						readString(dataInputStream), readString(dataInputStream));
 			}
 
-			if (InstrumentUtils.isCustomInstrument((byte) (biggestInstrumentIndex - custom))){
-				ArrayList<CustomInstrument> ci = CompatibilityUtils.get1_12Instruments();
-				ci.addAll(Arrays.asList(customInstruments));
-				customInstruments = ci.toArray(customInstruments);
+			if (InstrumentUtils.isCustomInstrument((byte) (biggestInstrumentIndex - customAmnt))) {
+				ArrayList<CustomInstrument> customInstruments = CompatibilityUtils.get1_12Instruments();
+				customInstruments.addAll(Arrays.asList(customInstrumentsArray));
+				customInstrumentsArray = customInstruments.toArray(customInstrumentsArray);
 			}
 
 			return new Song(speed, layerHashMap, songHeight, length, title, 
-					author, description, songFile, customInstruments);
+					author, description, songFile, customInstrumentsArray);
 		} catch (FileNotFoundException e) {
 			e.printStackTrace();
-		} catch (EOFException e){
+		} catch (EOFException e) {
 			String file = "";
-			if (songFile != null){
+			if (songFile != null) {
 				file = songFile.getName();
 			}
 			Bukkit.getServer().getConsoleSender().sendMessage(ChatColor.RED + "Song is corrupted: " + file);
@@ -140,7 +140,7 @@ public class NBSDecoder {
 	}
 
 	/**
-	 * Sets a note at a tick in a given
+	 * Sets a note at a tick in a song
 	 * @param layerIndex
 	 * @param ticks
 	 * @param instrument

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/NBSDecoder.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/NBSDecoder.java
@@ -14,22 +14,45 @@ import java.util.HashMap;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 
+/**
+ * Utils for reading Note Block Studio data
+ *
+ */
 public class NBSDecoder {
 
-	public static Song parse(File decodeFile) {
+	/**
+	 * Parses a Song from a Note Block Studio project file (.nbs)
+	 * @see Song
+	 * @param .nbs file
+	 * @return Song object representing a Note Block Studio project
+	 */
+	public static Song parse(File songFile) {
 		try {
-			return parse(new FileInputStream(decodeFile), decodeFile);
+			return parse(new FileInputStream(songFile), songFile);
 		} catch (FileNotFoundException e) {
 			e.printStackTrace();
 		}
 		return null;
 	}
 
+	/**
+	 * Parses a Song from an InputStream
+	 * @see Song
+	 * @param inputStream of a Note Block Studio project file (.nbs)
+	 * @return Song object from the InputStream
+	 */
 	public static Song parse(InputStream inputStream) {
 		return parse(inputStream, null); // Source is unknown -> no file
 	}
 
-	private static Song parse(InputStream inputStream, File decodeFile) {
+	/**
+	 * Parses a Song from an InputStream and a Note Block Studio project file (.nbs)
+	 * @see Song
+	 * @param inputStream of a .nbs file
+	 * @param songFile representing a .nbs file
+	 * @return Song object representing the given .nbs file
+	 */
+	private static Song parse(InputStream inputStream, File songFile) {
 		HashMap<Integer, Layer> layerHashMap = new HashMap<Integer, Layer>();
 		byte biggestInstrumentIndex = -1;
 		try {
@@ -94,20 +117,20 @@ public class NBSDecoder {
 						readString(dataInputStream), readString(dataInputStream));
 			}
 
-			if (Instrument.isCustomInstrument((byte) (biggestInstrumentIndex - custom))){
+			if (InstrumentUtils.isCustomInstrument((byte) (biggestInstrumentIndex - custom))){
 				ArrayList<CustomInstrument> ci = CompatibilityUtils.get1_12Instruments();
 				ci.addAll(Arrays.asList(customInstruments));
 				customInstruments = ci.toArray(customInstruments);
 			}
 
 			return new Song(speed, layerHashMap, songHeight, length, title, 
-					author, description, decodeFile, customInstruments);
+					author, description, songFile, customInstruments);
 		} catch (FileNotFoundException e) {
 			e.printStackTrace();
 		} catch (EOFException e){
 			String file = "";
-			if (decodeFile != null){
-				file = decodeFile.getName();
+			if (songFile != null){
+				file = songFile.getName();
 			}
 			Bukkit.getServer().getConsoleSender().sendMessage(ChatColor.RED + "Song is corrupted: " + file);
 		} catch (IOException e) {
@@ -116,6 +139,14 @@ public class NBSDecoder {
 		return null;
 	}
 
+	/**
+	 * Sets a note at a tick in a given
+	 * @param layerIndex
+	 * @param ticks
+	 * @param instrument
+	 * @param key
+	 * @param layerHashMap
+	 */
 	private static void setNote(int layerIndex, int ticks, byte instrument, 
 			byte key, HashMap<Integer, Layer> layerHashMap) {
 		Layer layer = layerHashMap.get(layerIndex);

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/NBSDecoder.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/NBSDecoder.java
@@ -16,136 +16,140 @@ import org.bukkit.ChatColor;
 
 public class NBSDecoder {
 
-    public static Song parse(File decodeFile) {
-        try {
-            return parse(new FileInputStream(decodeFile), decodeFile);
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-        }
-        return null;
-    }
+	public static Song parse(File decodeFile) {
+		try {
+			return parse(new FileInputStream(decodeFile), decodeFile);
+		} catch (FileNotFoundException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
 
-    public static Song parse(InputStream inputStream) {
-        return parse(inputStream, null); // Source is unknown -> no file
-    }
+	public static Song parse(InputStream inputStream) {
+		return parse(inputStream, null); // Source is unknown -> no file
+	}
 
-    private static Song parse(InputStream inputStream, File decodeFile) {
-        HashMap<Integer, Layer> layerHashMap = new HashMap<Integer, Layer>();
-        byte biggestInstrumentIndex = -1;
-        try {
-            DataInputStream dis = new DataInputStream(inputStream);
-            short length = readShort(dis);
-            short songHeight = readShort(dis);
-            String title = readString(dis);
-            String author = readString(dis);
-            readString(dis);
-            String description = readString(dis);
-            float speed = readShort(dis) / 100f;
-            dis.readBoolean(); // auto-save
-            dis.readByte(); // auto-save duration
-            dis.readByte(); // x/4ths, time signature
-            readInt(dis); // minutes spent on project
-            readInt(dis); // left clicks (why?)
-            readInt(dis); // right clicks (why?)
-            readInt(dis); // blocks added
-            readInt(dis); // blocks removed
-            readString(dis); // .mid/.schematic file name
-            short tick = -1;
-            while (true) {
-                short jumpTicks = readShort(dis); // jumps till next tick
-                //System.out.println("Jumps to next tick: " + jumpTicks);
-                if (jumpTicks == 0) {
-                    break;
-                }
-                tick += jumpTicks;
-                //System.out.println("Tick: " + tick);
-                short layer = -1;
-                while (true) {
-                    short jumpLayers = readShort(dis); // jumps till next layer
-                    if (jumpLayers == 0) {
-                        break;
-                    }
-                    layer += jumpLayers;
-                    //System.out.println("Layer: " + layer);
-                    byte instrument = dis.readByte();
-                    if (instrument > biggestInstrumentIndex){
-                    	biggestInstrumentIndex = instrument;
-                    }
-                    setNote(layer, tick, instrument /* instrument */, dis.readByte() /* note */, layerHashMap);
-                }
-            }
-            for (int i = 0; i < songHeight; i++) {
-                Layer l = layerHashMap.get(i);
-                
-            	String name = readString(dis);
-            	byte volume = dis.readByte();
-                if (l != null) {
-                    l.setName(name);
-                    l.setVolume(volume);
-                }
-            }
-            //count of custom instruments
-            byte custom = dis.readByte();
-            CustomInstrument[] customInstruments = new CustomInstrument[custom];
+	private static Song parse(InputStream inputStream, File decodeFile) {
+		HashMap<Integer, Layer> layerHashMap = new HashMap<Integer, Layer>();
+		byte biggestInstrumentIndex = -1;
+		try {
+			DataInputStream dataInputStream = new DataInputStream(inputStream);
+			short length = readShort(dataInputStream);
+			short songHeight = readShort(dataInputStream);
+			String title = readString(dataInputStream);
+			String author = readString(dataInputStream);
+			readString(dataInputStream);
+			String description = readString(dataInputStream);
+			float speed = readShort(dataInputStream) / 100f;
+			dataInputStream.readBoolean(); // auto-save
+			dataInputStream.readByte(); // auto-save duration
+			dataInputStream.readByte(); // x/4ths, time signature
+			readInt(dataInputStream); // minutes spent on project
+			readInt(dataInputStream); // left clicks (why?)
+			readInt(dataInputStream); // right clicks (why?)
+			readInt(dataInputStream); // blocks added
+			readInt(dataInputStream); // blocks removed
+			readString(dataInputStream); // .mid/.schematic file name
+			short tick = -1;
+			while (true) {
+				short jumpTicks = readShort(dataInputStream); // jumps till next tick
+				//System.out.println("Jumps to next tick: " + jumpTicks);
+				if (jumpTicks == 0) {
+					break;
+				}
+				tick += jumpTicks;
+				//System.out.println("Tick: " + tick);
+				short layer = -1;
+				while (true) {
+					short jumpLayers = readShort(dataInputStream); // jumps till next layer
+					if (jumpLayers == 0) {
+						break;
+					}
+					layer += jumpLayers;
+					//System.out.println("Layer: " + layer);
+					byte instrument = dataInputStream.readByte();
+					if (instrument > biggestInstrumentIndex) {
+						biggestInstrumentIndex = instrument;
+					}
+					setNote(layer, tick, instrument /* instrument */, 
+							dataInputStream.readByte() /* note */, layerHashMap);
+				}
+			}
+			for (int i = 0; i < songHeight; i++) {
+				Layer l = layerHashMap.get(i);
 
-            for (int i = 0; i < custom; i++) {
-                customInstruments[i] = new CustomInstrument((byte)i, readString(dis), readString(dis), dis.readByte(), dis.readByte());
-            }
-            
-            if (Instrument.isCustomInstrument((byte) (biggestInstrumentIndex - custom))){
-            	ArrayList<CustomInstrument> ci = CompatibilityUtils.get1_12Instruments();
-            	ci.addAll(Arrays.asList(customInstruments));
-            	customInstruments = ci.toArray(customInstruments);
-            }
-            
-            return new Song(speed, layerHashMap, songHeight, length, title, author, description, decodeFile, customInstruments);
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-        } catch (EOFException e){
-        	String file = "";
-        	if (decodeFile != null){
-        		file = decodeFile.getName();
-        	}
-        	Bukkit.getServer().getConsoleSender().sendMessage(ChatColor.RED + "Song is corrupted " + file);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return null;
-    }
+				String name = readString(dataInputStream);
+				byte volume = dataInputStream.readByte();
+				if (l != null) {
+					l.setName(name);
+					l.setVolume(volume);
+				}
+			}
+			//count of custom instruments
+			byte custom = dataInputStream.readByte();
+			CustomInstrument[] customInstruments = new CustomInstrument[custom];
 
-    private static void setNote(int layer, int ticks, byte instrument, byte key, HashMap<Integer, Layer> layerHashMap) {
-        Layer l = layerHashMap.get(layer);
-        if (l == null) {
-            l = new Layer();
-            layerHashMap.put(layer, l);
-        }
-        l.setNote(ticks, new Note(instrument, key));
-    }
+			for (int index = 0; index < custom; index++) {
+				customInstruments[index] = new CustomInstrument((byte) index, 
+						readString(dataInputStream), readString(dataInputStream));
+			}
 
-    private static short readShort(DataInputStream dis) throws IOException {
-        int byte1 = dis.readUnsignedByte();
-        int byte2 = dis.readUnsignedByte();
-        return (short) (byte1 + (byte2 << 8));
-    }
+			if (Instrument.isCustomInstrument((byte) (biggestInstrumentIndex - custom))){
+				ArrayList<CustomInstrument> ci = CompatibilityUtils.get1_12Instruments();
+				ci.addAll(Arrays.asList(customInstruments));
+				customInstruments = ci.toArray(customInstruments);
+			}
 
-    private static int readInt(DataInputStream dis) throws IOException {
-        int byte1 = dis.readUnsignedByte();
-        int byte2 = dis.readUnsignedByte();
-        int byte3 = dis.readUnsignedByte();
-        int byte4 = dis.readUnsignedByte();
-        return (byte1 + (byte2 << 8) + (byte3 << 16) + (byte4 << 24));
-    }
+			return new Song(speed, layerHashMap, songHeight, length, title, 
+					author, description, decodeFile, customInstruments);
+		} catch (FileNotFoundException e) {
+			e.printStackTrace();
+		} catch (EOFException e){
+			String file = "";
+			if (decodeFile != null){
+				file = decodeFile.getName();
+			}
+			Bukkit.getServer().getConsoleSender().sendMessage(ChatColor.RED + "Song is corrupted: " + file);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
 
-    private static String readString(DataInputStream dis) throws IOException {
-        int length = readInt(dis);
-        StringBuilder sb = new StringBuilder(length);
-        for (; length > 0; --length) {
-            char c = (char) dis.readByte();
-            if (c == (char) 0x0D) {
-                c = ' ';
-            }
-            sb.append(c);
-        }
-        return sb.toString();
-    }
+	private static void setNote(int layerIndex, int ticks, byte instrument, 
+			byte key, HashMap<Integer, Layer> layerHashMap) {
+		Layer layer = layerHashMap.get(layerIndex);
+		if (layer == null) {
+			layer = new Layer();
+			layerHashMap.put(layerIndex, layer);
+		}
+		layer.setNote(ticks, new Note(instrument, key));
+	}
+
+	private static short readShort(DataInputStream dataInputStream) throws IOException {
+		int byte1 = dataInputStream.readUnsignedByte();
+		int byte2 = dataInputStream.readUnsignedByte();
+		return (short) (byte1 + (byte2 << 8));
+	}
+
+	private static int readInt(DataInputStream dataInputStream) throws IOException {
+		int byte1 = dataInputStream.readUnsignedByte();
+		int byte2 = dataInputStream.readUnsignedByte();
+		int byte3 = dataInputStream.readUnsignedByte();
+		int byte4 = dataInputStream.readUnsignedByte();
+		return (byte1 + (byte2 << 8) + (byte3 << 16) + (byte4 << 24));
+	}
+
+	private static String readString(DataInputStream dataInputStream) throws IOException {
+		int length = readInt(dataInputStream);
+		StringBuilder builder = new StringBuilder(length);
+		for (; length > 0; --length) {
+			char c = (char) dataInputStream.readByte();
+			if (c == (char) 0x0D) {
+				c = ' ';
+			}
+			builder.append(c);
+		}
+		return builder.toString();
+	}
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Note.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Note.java
@@ -1,5 +1,10 @@
 package com.xxmicloxx.NoteBlockAPI;
 
+/**
+ * Represents a note played; contains the instrument and the key
+ * @see NotePitch
+ *
+ */
 public class Note {
 
 	private byte instrument;

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Note.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Note.java
@@ -2,27 +2,28 @@ package com.xxmicloxx.NoteBlockAPI;
 
 public class Note {
 
-    private byte instrument;
-    private byte key;
+	private byte instrument;
+	private byte key;
 
-    public Note(byte instrument, byte key) {
-        this.instrument = instrument;
-        this.key = key;
-    }
+	public Note(byte instrument, byte key) {
+		this.instrument = instrument;
+		this.key = key;
+	}
 
-    public byte getInstrument() {
-        return instrument;
-    }
+	public byte getInstrument() {
+		return instrument;
+	}
 
-    public void setInstrument(byte instrument) {
-        this.instrument = instrument;
-    }
+	public void setInstrument(byte instrument) {
+		this.instrument = instrument;
+	}
 
-    public byte getKey() {
-        return key;
-    }
+	public byte getKey() {
+		return key;
+	}
 
-    public void setKey(byte key) {
-        this.key = key;
-    }
+	public void setKey(byte key) {
+		this.key = key;
+	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockPlayerMain.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockPlayerMain.java
@@ -4,45 +4,69 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.bstats.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
+/**
+ * Main class; contains methods for playing and adjusting songs for players
+ *
+ */
 public class NoteBlockPlayerMain extends JavaPlugin {
 
 	public static NoteBlockPlayerMain plugin;
 
-	public Map<String, ArrayList<SongPlayer>> playingSongs = 
-			Collections.synchronizedMap(new HashMap<String, ArrayList<SongPlayer>>());
-	public Map<String, Byte> playerVolume = Collections.synchronizedMap(new HashMap<String, Byte>());
+	public Map<UUID, ArrayList<SongPlayer>> playingSongs = 
+			Collections.synchronizedMap(new HashMap<UUID, ArrayList<SongPlayer>>());
+	public Map<UUID, Byte> playerVolume = Collections.synchronizedMap(new HashMap<UUID, Byte>());
 
 	private boolean disabling = false;
 
-	public static boolean isReceivingSong(Player p) {
-		return ((plugin.playingSongs.get(p.getName()) != null) 
-				&& (!plugin.playingSongs.get(p.getName()).isEmpty()));
+	/**
+	 * Returns true if a Player is currently receiving a song
+	 * @param player
+	 * @return is receiving a song
+	 */
+	public static boolean isReceivingSong(Player player) {
+		return ((plugin.playingSongs.get(player.getUniqueId()) != null) 
+				&& (!plugin.playingSongs.get(player.getUniqueId()).isEmpty()));
 	}
 
+	/**
+	 * Stops the song for a Player
+	 * @param player
+	 */
 	public static void stopPlaying(Player player) {
-		if (plugin.playingSongs.get(player.getName()) == null) {
+		if (plugin.playingSongs.get(player.getUniqueId()) == null) {
 			return;
 		}
-		for (SongPlayer songPlayer : plugin.playingSongs.get(player.getName())) {
+		for (SongPlayer songPlayer : plugin.playingSongs.get(player.getUniqueId())) {
 			songPlayer.removePlayer(player);
 		}
 	}
 
+	/**
+	 * Sets the volume for a given Player
+	 * @param player
+	 * @param volume
+	 */
 	public static void setPlayerVolume(Player player, byte volume) {
-		plugin.playerVolume.put(player.getName(), volume);
+		plugin.playerVolume.put(player.getUniqueId(), volume);
 	}
 
+	/**
+	 * Gets the volume for a given Player
+	 * @param player
+	 * @return volume (byte)
+	 */
 	public static byte getPlayerVolume(Player player) {
-		Byte byteObj = plugin.playerVolume.get(player.getName());
+		Byte byteObj = plugin.playerVolume.get(player.getUniqueId());
 		if (byteObj == null) {
 			byteObj = 100;
-			plugin.playerVolume.put(player.getName(), byteObj);
+			plugin.playerVolume.put(player.getUniqueId(), byteObj);
 		}
 		return byteObj;
 	}

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockPlayerMain.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockPlayerMain.java
@@ -12,61 +12,63 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public class NoteBlockPlayerMain extends JavaPlugin {
 
-    public static NoteBlockPlayerMain plugin;
-    
-    public Map<String, ArrayList<SongPlayer>> playingSongs = Collections.synchronizedMap(new HashMap<String, ArrayList<SongPlayer>>());
-    public Map<String, Byte> playerVolume = Collections.synchronizedMap(new HashMap<String, Byte>());
+	public static NoteBlockPlayerMain plugin;
 
-    private boolean disabling = false;
-    
-    public static boolean isReceivingSong(Player p) {
-        return ((plugin.playingSongs.get(p.getName()) != null) && (!plugin.playingSongs.get(p.getName()).isEmpty()));
-    }
+	public Map<String, ArrayList<SongPlayer>> playingSongs = 
+			Collections.synchronizedMap(new HashMap<String, ArrayList<SongPlayer>>());
+	public Map<String, Byte> playerVolume = Collections.synchronizedMap(new HashMap<String, Byte>());
 
-    public static void stopPlaying(Player p) {
-        if (plugin.playingSongs.get(p.getName()) == null) {
-            return;
-        }
-        for (SongPlayer s : plugin.playingSongs.get(p.getName())) {
-            s.removePlayer(p);
-        }
-    }
+	private boolean disabling = false;
 
-    public static void setPlayerVolume(Player p, byte volume) {
-        plugin.playerVolume.put(p.getName(), volume);
-    }
+	public static boolean isReceivingSong(Player p) {
+		return ((plugin.playingSongs.get(p.getName()) != null) 
+				&& (!plugin.playingSongs.get(p.getName()).isEmpty()));
+	}
 
-    public static byte getPlayerVolume(Player p) {
-        Byte b = plugin.playerVolume.get(p.getName());
-        if (b == null) {
-            b = 100;
-            plugin.playerVolume.put(p.getName(), b);
-        }
-        return b;
-    }
+	public static void stopPlaying(Player player) {
+		if (plugin.playingSongs.get(player.getName()) == null) {
+			return;
+		}
+		for (SongPlayer songPlayer : plugin.playingSongs.get(player.getName())) {
+			songPlayer.removePlayer(player);
+		}
+	}
 
-    @Override
-    public void onEnable() {
-        plugin = this;
-        new Metrics(this);
-    }
+	public static void setPlayerVolume(Player player, byte volume) {
+		plugin.playerVolume.put(player.getName(), volume);
+	}
 
-    @Override
-    public void onDisable() {    	
-    	disabling = true;
-        Bukkit.getScheduler().cancelTasks(this);
-    }
-    
-    public void doSync(Runnable r) {
-        getServer().getScheduler().runTask(this, r);
-    }
+	public static byte getPlayerVolume(Player player) {
+		Byte byteObj = plugin.playerVolume.get(player.getName());
+		if (byteObj == null) {
+			byteObj = 100;
+			plugin.playerVolume.put(player.getName(), byteObj);
+		}
+		return byteObj;
+	}
 
-    public void doAsync(Runnable r) {
-        getServer().getScheduler().runTaskAsynchronously(this, r);
-    }
-    
-    protected boolean isDisabling(){
-    	return disabling;
-    }
-     
+	@Override
+	public void onEnable() {
+		plugin = this;
+		new Metrics(this);
+	}
+
+	@Override
+	public void onDisable() {    	
+		disabling = true;
+		Bukkit.getScheduler().cancelTasks(this);
+	}
+
+	public void doSync(Runnable runnable) {
+		getServer().getScheduler().runTask(this, runnable);
+	}
+
+	public void doAsync(Runnable runnable) {
+		getServer().getScheduler().runTaskAsynchronously(this, runnable);
+	}
+
+	protected boolean isDisabling() {
+		return disabling;
+	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockSongPlayer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockSongPlayer.java
@@ -5,6 +5,10 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
+/**
+ * SongPlayer created at a specified NoteBlock
+ *
+ */
 public class NoteBlockSongPlayer extends SongPlayer {
 
 	private Block noteBlock;
@@ -18,10 +22,17 @@ public class NoteBlockSongPlayer extends SongPlayer {
 		super(song, soundCategory);
 	}
 
+	/**
+	 * Get the Block this SongPlayer is played at
+	 * @return Block representing a NoteBlock
+	 */
 	public Block getNoteBlock() {
 		return noteBlock;
 	}
 
+	/**
+	 * Set the Block this SongPlayer is played at
+	 */
 	public void setNoteBlock(Block noteBlock) {
 		this.noteBlock = noteBlock;
 	}
@@ -42,16 +53,16 @@ public class NoteBlockSongPlayer extends SongPlayer {
 			if (note == null) {
 				continue;
 			}
-			player.playNote(noteBlock.getLocation(), Instrument.getBukkitInstrument(note.getInstrument()),
+			player.playNote(noteBlock.getLocation(), InstrumentUtils.getBukkitInstrument(note.getInstrument()),
 					new org.bukkit.Note(note.getKey() - 33));
 
 			float volume = ((layer.getVolume() * (int) this.volume * (int) playerVolume) / 1000000F) 
 					* ((1F / 16F) * distance);
 			float pitch = NotePitch.getPitch(note.getKey() - 33);
 
-			if (Instrument.isCustomInstrument(note.getInstrument())) {
+			if (InstrumentUtils.isCustomInstrument(note.getInstrument())) {
 				CustomInstrument instrument = song.getCustomInstruments()
-						[note.getInstrument() - Instrument.getCustomInstrumentFirstIndex()];
+						[note.getInstrument() - InstrumentUtils.getCustomInstrumentFirstIndex()];
 
 				if (instrument.getSound() != null) {
 					CompatibilityUtils.playSound(player, noteBlock.getLocation(), 
@@ -62,17 +73,17 @@ public class NoteBlockSongPlayer extends SongPlayer {
 				}
 			} else {
 				CompatibilityUtils.playSound(player, noteBlock.getLocation(),
-						Instrument.getInstrument(note.getInstrument()), this.soundCategory, volume, pitch);
+						InstrumentUtils.getInstrument(note.getInstrument()), this.soundCategory, volume, pitch);
 			}
 
 			if (isInRange(player)) {
-				if (!this.playerList.get(player.getName())) {
-					playerList.put(player.getName(), true);
+				if (!this.playerList.get(player.getUniqueId())) {
+					playerList.put(player.getUniqueId(), true);
 					Bukkit.getPluginManager().callEvent(new PlayerRangeStateChangeEvent(this, player, true));
 				}
 			} else {
-				if (this.playerList.get(player.getName())) {
-					playerList.put(player.getName(), false);
+				if (this.playerList.get(player.getUniqueId())) {
+					playerList.put(player.getUniqueId(), false);
 					Bukkit.getPluginManager().callEvent(new PlayerRangeStateChangeEvent(this, player, false));
 				}
 			}
@@ -80,13 +91,17 @@ public class NoteBlockSongPlayer extends SongPlayer {
 	}
 
 	/**
-	 * Sets distance in blocks where would be player able to hear sound. 
-	 * @param distance (Default 16 blocks)
+	 * Sets distance in blocks where the player would be able to hear sound 
+	 * @param distance (default 16 blocks)
 	 */
 	public void setDistance(int distance) {
 		this.distance = distance;
 	}
 
+	/**
+	 * Gets distance in blocks where the player is able to hear sound 
+	 * @return distance (default 16 blocks)
+	 */
 	public int getDistance() {
 		return distance;
 	}
@@ -96,6 +111,11 @@ public class NoteBlockSongPlayer extends SongPlayer {
 		return isInRange(player);
 	}
 
+	/**
+	 * Returns true if the Player is able to hear the current NoteBlockSongPlayer 
+	 * @param player in range
+	 * @return ability to hear the current NoteBlockSongPlayer
+	 */
 	public boolean isInRange(Player player) {
 		if (player.getLocation().distance(noteBlock.getLocation()) > distance) {
 			return false;

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/NotePitch.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/NotePitch.java
@@ -5,48 +5,50 @@ import com.xxmicloxx.NoteBlockAPI.CompatibilityUtils.NoteBlockCompatibility;
 public enum NotePitch {
 
 	NOTE_0(0, 0.5F, 0.50000F),
-    NOTE_1(1, 0.53F, 0.52973F),
-    NOTE_2(2, 0.56F, 0.56123F),
-    NOTE_3(3, 0.6F, 0.59461F),
-    NOTE_4(4, 0.63F, 0.62995F),
-    NOTE_5(5, 0.67F, 0.66741F),
-    NOTE_6(6, 0.7F, 0.70711F),
-    NOTE_7(7, 0.76F, 0.74916F),
-    NOTE_8(8, 0.8F, 0.79370F),
-    NOTE_9(9, 0.84F, 0.84089F),
-    NOTE_10(10, 0.9F, 0.89091F),
-    NOTE_11(11, 0.94F, 0.94386F),
-    NOTE_12(12, 1.0F, 1.00000F),
-    NOTE_13(13, 1.06F, 1.05945F),
-    NOTE_14(14, 1.12F, 1.12245F),
-    NOTE_15(15, 1.18F, 1.18920F),
-    NOTE_16(16, 1.26F, 1.25993F),
-    NOTE_17(17, 1.34F, 1.33484F),
-    NOTE_18(18, 1.42F, 1.41420F),
-    NOTE_19(19, 1.5F, 1.49832F),
-    NOTE_20(20, 1.6F, 1.58741F),
-    NOTE_21(21, 1.68F, 1.68180F),
-    NOTE_22(22, 1.78F, 1.78180F),
-    NOTE_23(23, 1.88F, 1.88775F),
-    NOTE_24(24, 2.0F, 2.00000F);
+	NOTE_1(1, 0.53F, 0.52973F),
+	NOTE_2(2, 0.56F, 0.56123F),
+	NOTE_3(3, 0.6F, 0.59461F),
+	NOTE_4(4, 0.63F, 0.62995F),
+	NOTE_5(5, 0.67F, 0.66741F),
+	NOTE_6(6, 0.7F, 0.70711F),
+	NOTE_7(7, 0.76F, 0.74916F),
+	NOTE_8(8, 0.8F, 0.79370F),
+	NOTE_9(9, 0.84F, 0.84089F),
+	NOTE_10(10, 0.9F, 0.89091F),
+	NOTE_11(11, 0.94F, 0.94386F),
+	NOTE_12(12, 1.0F, 1.00000F),
+	NOTE_13(13, 1.06F, 1.05945F),
+	NOTE_14(14, 1.12F, 1.12245F),
+	NOTE_15(15, 1.18F, 1.18920F),
+	NOTE_16(16, 1.26F, 1.25993F),
+	NOTE_17(17, 1.34F, 1.33484F),
+	NOTE_18(18, 1.42F, 1.41420F),
+	NOTE_19(19, 1.5F, 1.49832F),
+	NOTE_20(20, 1.6F, 1.58741F),
+	NOTE_21(21, 1.68F, 1.68180F),
+	NOTE_22(22, 1.78F, 1.78180F),
+	NOTE_23(23, 1.88F, 1.88775F),
+	NOTE_24(24, 2.0F, 2.00000F);
 
-    public int note;
-    public float pitchPre1_9;
-    public float pitchPost1_9;
+	public int note;
+	public float pitchPre1_9;
+	public float pitchPost1_9;
 
-    private NotePitch(int note, float pitchPre1_9, float pitchPost1_9) {
-        this.note = note;
-        this.pitchPre1_9 = pitchPre1_9;
-        this.pitchPost1_9 = pitchPost1_9;
-    }
+	private NotePitch(int note, float pitchPre1_9, float pitchPost1_9) {
+		this.note = note;
+		this.pitchPre1_9 = pitchPre1_9;
+		this.pitchPost1_9 = pitchPost1_9;
+	}
 
-    public static float getPitch(int note) {
-        for (NotePitch notePitch : values()) {
-            if (notePitch.note == note) {
-                return CompatibilityUtils.getCompatibility() == NoteBlockCompatibility.pre1_9 ? notePitch.pitchPre1_9 : notePitch.pitchPost1_9;
-            }
-        }
+	public static float getPitch(int note) {
+		for (NotePitch notePitch : values()) {
+			if (notePitch.note == note) {
+				return CompatibilityUtils.getCompatibility() == NoteBlockCompatibility.pre1_9 
+						? notePitch.pitchPre1_9 : notePitch.pitchPost1_9;
+			}
+		}
 
-        return 0.0F;
-    }
+		return 0.0F;
+	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/NotePitch.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/NotePitch.java
@@ -1,7 +1,11 @@
 package com.xxmicloxx.NoteBlockAPI;
 
-import com.xxmicloxx.NoteBlockAPI.CompatibilityUtils.NoteBlockCompatibility;
+import org.bukkit.Bukkit;
 
+/**
+ * Represents pitches of every noteblock note pre- & post-1.9
+ *
+ */
 public enum NotePitch {
 
 	NOTE_0(0, 0.5F, 0.50000F),
@@ -41,10 +45,10 @@ public enum NotePitch {
 	}
 
 	public static float getPitch(int note) {
+		boolean pre1_9 = Bukkit.getVersion().contains("1.8") || Bukkit.getVersion().contains("1.7");
 		for (NotePitch notePitch : values()) {
 			if (notePitch.note == note) {
-				return CompatibilityUtils.getCompatibility() == NoteBlockCompatibility.pre1_9 
-						? notePitch.pitchPre1_9 : notePitch.pitchPost1_9;
+				return pre1_9 ? notePitch.pitchPre1_9 : notePitch.pitchPost1_9;
 			}
 		}
 

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/PlayerRangeStateChangeEvent.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/PlayerRangeStateChangeEvent.java
@@ -4,37 +4,38 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
-public class PlayerRangeStateChangeEvent extends Event{
-	
+public class PlayerRangeStateChangeEvent extends Event {
+
 	private static final HandlerList handlers = new HandlerList();
 	private SongPlayer song;
-	private Player p;
-	private Boolean state;
+	private Player player;
+	private boolean state;
 
-    public PlayerRangeStateChangeEvent(SongPlayer song, Player p, Boolean state) {
-        this.song = song;
-        this.p = p;
-        this.state = state;
-    }
+	public PlayerRangeStateChangeEvent(SongPlayer song, Player player, boolean state) {
+		this.song = song;
+		this.player = player;
+		this.state = state;
+	}
 
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
 
-    public SongPlayer getSongPlayer() {
-        return song;
-    }
-    
-    @Override
-    public HandlerList getHandlers() {
-        return handlers;
-    }
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public SongPlayer getSongPlayer() {
+		return song;
+	}
 
 	public Player getPlayer() {
-		return p;
+		return player;
 	}
-	
-	public Boolean isInRange() {
+
+	public boolean isInRange() {
 		return state;
 	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/PlayerRangeStateChangeEvent.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/PlayerRangeStateChangeEvent.java
@@ -4,6 +4,10 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Called whenever a Player enters the range of a stationary SongPlayer
+ *
+ */
 public class PlayerRangeStateChangeEvent extends Event {
 
 	private static final HandlerList handlers = new HandlerList();

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/PositionSongPlayer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/PositionSongPlayer.java
@@ -6,92 +6,88 @@ import org.bukkit.entity.Player;
 
 public class PositionSongPlayer extends SongPlayer {
 
-    private Location targetLocation;
-    private int distance = 16;
+	private Location targetLocation;
+	private int distance = 16;
 
-    public PositionSongPlayer(Song song) {
-        super(song);
-    }
+	public PositionSongPlayer(Song song) {
+		super(song);
+	}
 
-    public PositionSongPlayer(Song song, SoundCategory soundCategory) {
-        super(song, soundCategory);
-    }
+	public PositionSongPlayer(Song song, SoundCategory soundCategory) {
+		super(song, soundCategory);
+	}
 
-    public Location getTargetLocation() {
-        return targetLocation;
-    }
+	public Location getTargetLocation() {
+		return targetLocation;
+	}
 
-    public void setTargetLocation(Location targetLocation) {
-        this.targetLocation = targetLocation;
-    }
+	public void setTargetLocation(Location targetLocation) {
+		this.targetLocation = targetLocation;
+	}
 
-    @Override
-    public void playTick(Player p, int tick) {
-        if (!p.getWorld().getName().equals(targetLocation.getWorld().getName())) {
-            // not in same world
-            return;
-        }
-        byte playerVolume = NoteBlockPlayerMain.getPlayerVolume(p);
+	@Override
+	public void playTick(Player player, int tick) {
+		if (!player.getWorld().getName().equals(targetLocation.getWorld().getName())) {
+			// not in same world
+			return;
+		}
+		byte playerVolume = NoteBlockPlayerMain.getPlayerVolume(player);
 
-        for (Layer l : song.getLayerHashMap().values()) {
-            Note note = l.getNote(tick);
-            if (note == null) {
-                continue;
-            }
-            
-            if (Instrument.isCustomInstrument(note.getInstrument())){
-            	if (song.getCustomInstruments()[note.getInstrument() - Instrument.getCustomInstrumentFirstIndex()].getSound() != null){
-            		CompatibilityUtils.playSound(p, targetLocation,
-                            song.getCustomInstruments()[note.getInstrument() - Instrument.getCustomInstrumentFirstIndex()].getSound(),
-                            this.soundCategory,((l.getVolume() * (int) volume * (int) playerVolume) / 1000000f) * ((1f/16f) * distance),
-                            NotePitch.getPitch(note.getKey() - 33));
-            	}else {
-            		CompatibilityUtils.playSound(p, targetLocation,
-                            song.getCustomInstruments()[note.getInstrument() - Instrument.getCustomInstrumentFirstIndex()].getSoundfile(),
-                            this.soundCategory,((l.getVolume() * (int) volume * (int) playerVolume) / 1000000f) * ((1f/16f) * distance),
-                            NotePitch.getPitch(note.getKey() - 33));
-            	}
-            	
-            }else {
-            	CompatibilityUtils.playSound(p, targetLocation,
-                    Instrument.getInstrument(note.getInstrument()),
-                    this.soundCategory,((l.getVolume() * (int) volume * (int) playerVolume) / 1000000f) * ((1f/16f) * distance),
-                    NotePitch.getPitch(note.getKey() - 33));
-            }
-            
-            if (isPlayerInRange(p)){
-            	if (!this.playerList.get(p.getName())){
-            		playerList.put(p.getName(), true);
-            		PlayerRangeStateChangeEvent event = new PlayerRangeStateChangeEvent(this, p, true);
-            		Bukkit.getPluginManager().callEvent(event);
-            	}
-            } else {
-            	if (this.playerList.get(p.getName())){
-            		playerList.put(p.getName(), false);
-            		PlayerRangeStateChangeEvent event = new PlayerRangeStateChangeEvent(this, p, false);
-            		Bukkit.getPluginManager().callEvent(event);
-            	}
-            }
-        }
-    }
-    
-    /**
-     * Sets distance in blocks where would be player able to hear sound. 
-     * @param distance (Default 16 blocks)
-     */
-    public void setDistance(int distance){
-    	this.distance = distance;
-    }
-    
-    public int getDistance(){
-    	return distance;
-    }
-    
-    public boolean isPlayerInRange(Player p){
-    	if (p.getLocation().distance(targetLocation) > distance){
-    		return false;
-    	} else {
-    		return true;
-    	}
-    }
+		for (Layer layer : song.getLayerHashMap().values()) {
+			Note note = layer.getNote(tick);
+			if (note == null) {
+				continue;
+			}
+
+			float volume = ((layer.getVolume() * (int) this.volume * (int) playerVolume) / 1000000F) 
+					* ((1F / 16F) * distance);
+			float pitch = NotePitch.getPitch(note.getKey() - 33);
+
+			if (Instrument.isCustomInstrument(note.getInstrument())) {
+				CustomInstrument instrument = song.getCustomInstruments()
+						[note.getInstrument() - Instrument.getCustomInstrumentFirstIndex()];
+
+				if (instrument.getSound() != null) {
+					CompatibilityUtils.playSound(player, targetLocation, instrument.getSound(),
+							this.soundCategory, volume, pitch);
+				} else {
+					CompatibilityUtils.playSound(player, targetLocation, instrument.getSoundFileName(),
+							this.soundCategory, volume, pitch);
+				}
+			} else {
+				CompatibilityUtils.playSound(player, targetLocation,
+						Instrument.getInstrument(note.getInstrument()), this.soundCategory, 
+						volume, pitch);
+			}
+
+			if (isPlayerInRange(player)) {
+				if (!this.playerList.get(player.getName())) {
+					playerList.put(player.getName(), true);
+					Bukkit.getPluginManager().callEvent(new PlayerRangeStateChangeEvent(this, player, true));
+				}
+			} else {
+				if (this.playerList.get(player.getName())) {
+					playerList.put(player.getName(), false);
+					Bukkit.getPluginManager().callEvent(new PlayerRangeStateChangeEvent(this, player, false));
+				}
+			}
+		}
+	}
+
+	/**
+	 * Sets distance in blocks where would be player able to hear sound. 
+	 * @param distance (Default 16 blocks)
+	 */
+	public void setDistance(int distance) {
+		this.distance = distance;
+	}
+
+	public int getDistance() {
+		return distance;
+	}
+
+	public boolean isPlayerInRange(Player player) {
+		return player.getLocation().distance(targetLocation) <= distance;
+	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/PositionSongPlayer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/PositionSongPlayer.java
@@ -4,6 +4,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
+/**
+ * SongPlayer created at a specified Location
+ *
+ */
 public class PositionSongPlayer extends SongPlayer {
 
 	private Location targetLocation;
@@ -28,24 +32,22 @@ public class PositionSongPlayer extends SongPlayer {
 	@Override
 	public void playTick(Player player, int tick) {
 		if (!player.getWorld().getName().equals(targetLocation.getWorld().getName())) {
-			// not in same world
-			return;
+			return; // not in same world
 		}
+
 		byte playerVolume = NoteBlockPlayerMain.getPlayerVolume(player);
 
 		for (Layer layer : song.getLayerHashMap().values()) {
 			Note note = layer.getNote(tick);
-			if (note == null) {
-				continue;
-			}
+			if (note == null) continue;
 
 			float volume = ((layer.getVolume() * (int) this.volume * (int) playerVolume) / 1000000F) 
 					* ((1F / 16F) * distance);
 			float pitch = NotePitch.getPitch(note.getKey() - 33);
 
-			if (Instrument.isCustomInstrument(note.getInstrument())) {
+			if (InstrumentUtils.isCustomInstrument(note.getInstrument())) {
 				CustomInstrument instrument = song.getCustomInstruments()
-						[note.getInstrument() - Instrument.getCustomInstrumentFirstIndex()];
+						[note.getInstrument() - InstrumentUtils.getCustomInstrumentFirstIndex()];
 
 				if (instrument.getSound() != null) {
 					CompatibilityUtils.playSound(player, targetLocation, instrument.getSound(),
@@ -56,18 +58,18 @@ public class PositionSongPlayer extends SongPlayer {
 				}
 			} else {
 				CompatibilityUtils.playSound(player, targetLocation,
-						Instrument.getInstrument(note.getInstrument()), this.soundCategory, 
+						InstrumentUtils.getInstrument(note.getInstrument()), this.soundCategory, 
 						volume, pitch);
 			}
 
 			if (isPlayerInRange(player)) {
-				if (!this.playerList.get(player.getName())) {
-					playerList.put(player.getName(), true);
+				if (!this.playerList.get(player.getUniqueId())) {
+					playerList.put(player.getUniqueId(), true);
 					Bukkit.getPluginManager().callEvent(new PlayerRangeStateChangeEvent(this, player, true));
 				}
 			} else {
-				if (this.playerList.get(player.getName())) {
-					playerList.put(player.getName(), false);
+				if (this.playerList.get(player.getUniqueId())) {
+					playerList.put(player.getUniqueId(), false);
 					Bukkit.getPluginManager().callEvent(new PlayerRangeStateChangeEvent(this, player, false));
 				}
 			}

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/RadioSongPlayer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/RadioSongPlayer.java
@@ -2,6 +2,10 @@ package com.xxmicloxx.NoteBlockAPI;
 
 import org.bukkit.entity.Player;
 
+/**
+ * SongPlayer created at a Player's location
+ *
+ */
 public class RadioSongPlayer extends SongPlayer {
 
 	public RadioSongPlayer(Song song) {
@@ -25,9 +29,9 @@ public class RadioSongPlayer extends SongPlayer {
 			float volume = (layer.getVolume() * (int) this.volume * (int) playerVolume) / 1000000F;
 			float pitch = NotePitch.getPitch(note.getKey() - 33);
 
-			if (Instrument.isCustomInstrument(note.getInstrument())) {
+			if (InstrumentUtils.isCustomInstrument(note.getInstrument())) {
 				CustomInstrument instrument = song.getCustomInstruments()
-						[note.getInstrument() - Instrument.getCustomInstrumentFirstIndex()];
+						[note.getInstrument() - InstrumentUtils.getCustomInstrumentFirstIndex()];
 
 				if (instrument.getSound() != null) {
 					CompatibilityUtils.playSound(player, player.getEyeLocation(),
@@ -40,7 +44,7 @@ public class RadioSongPlayer extends SongPlayer {
 				}
 			} else {
 				CompatibilityUtils.playSound(player, player.getEyeLocation(),
-						Instrument.getInstrument(note.getInstrument()), this.soundCategory, volume, pitch);
+						InstrumentUtils.getInstrument(note.getInstrument()), this.soundCategory, volume, pitch);
 			}
 		}
 	}

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/RadioSongPlayer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/RadioSongPlayer.java
@@ -4,42 +4,45 @@ import org.bukkit.entity.Player;
 
 public class RadioSongPlayer extends SongPlayer {
 
-    public RadioSongPlayer(Song song) {
-        super(song);
-    }
+	public RadioSongPlayer(Song song) {
+		super(song);
+	}
 
-    public RadioSongPlayer(Song song, SoundCategory soundCategory) {
-    	super(song, soundCategory);
-    }
+	public RadioSongPlayer(Song song, SoundCategory soundCategory) {
+		super(song, soundCategory);
+	}
 
-    @Override
-    public void playTick(Player p, int tick) {
-        byte playerVolume = NoteBlockPlayerMain.getPlayerVolume(p);
+	@Override
+	public void playTick(Player player, int tick) {
+		byte playerVolume = NoteBlockPlayerMain.getPlayerVolume(player);
 
-        for (Layer l : song.getLayerHashMap().values()) {
-            Note note = l.getNote(tick);
-            if (note == null) {
-                continue;
-            }
-            if (Instrument.isCustomInstrument(note.getInstrument())){
-            	if (song.getCustomInstruments()[note.getInstrument() - Instrument.getCustomInstrumentFirstIndex()].getSound() != null){
-            		CompatibilityUtils.playSound(p, p.getEyeLocation(),
-                            song.getCustomInstruments()[note.getInstrument() - Instrument.getCustomInstrumentFirstIndex()].getSound(),
-                            this.soundCategory,(l.getVolume() * (int) volume * (int) playerVolume) / 1000000f,
-                            NotePitch.getPitch(note.getKey() - 33));
-            	}else {
-            		CompatibilityUtils.playSound(p, p.getEyeLocation(),
-                            song.getCustomInstruments()[note.getInstrument() - Instrument.getCustomInstrumentFirstIndex()].getSoundfile(),
-                            this.soundCategory,(l.getVolume() * (int) volume * (int) playerVolume) / 1000000f,
-                            NotePitch.getPitch(note.getKey() - 33));
-            	}
-            	
-            }else {
-            	CompatibilityUtils.playSound(p, p.getEyeLocation(),
-                    Instrument.getInstrument(note.getInstrument()),
-                    this.soundCategory,(l.getVolume() * (int) volume * (int) playerVolume) / 1000000f,
-                    NotePitch.getPitch(note.getKey() - 33));
-            }
-        }
-    }
+		for (Layer layer : song.getLayerHashMap().values()) {
+			Note note = layer.getNote(tick);
+			if (note == null) {
+				continue;
+			}
+
+			float volume = (layer.getVolume() * (int) this.volume * (int) playerVolume) / 1000000F;
+			float pitch = NotePitch.getPitch(note.getKey() - 33);
+
+			if (Instrument.isCustomInstrument(note.getInstrument())) {
+				CustomInstrument instrument = song.getCustomInstruments()
+						[note.getInstrument() - Instrument.getCustomInstrumentFirstIndex()];
+
+				if (instrument.getSound() != null) {
+					CompatibilityUtils.playSound(player, player.getEyeLocation(),
+							instrument.getSound(),
+							this.soundCategory, volume, pitch);
+				} else {
+					CompatibilityUtils.playSound(player, player.getEyeLocation(),
+							instrument.getSoundFileName(),
+							this.soundCategory, volume, pitch);
+				}
+			} else {
+				CompatibilityUtils.playSound(player, player.getEyeLocation(),
+						Instrument.getInstrument(note.getInstrument()), this.soundCategory, volume, pitch);
+			}
+		}
+	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Song.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Song.java
@@ -5,77 +5,82 @@ import java.util.HashMap;
 
 public class Song {
 
-    private HashMap<Integer, Layer> layerHashMap = new HashMap<Integer, Layer>();
-    private short songHeight;
-    private short length;
-    private String title;
-    private File path;
-    private String author;
-    private String description;
-    private float speed;
-    private float delay;
-    private CustomInstrument[] customInstrument;
+	private HashMap<Integer, Layer> layerHashMap = new HashMap<Integer, Layer>();
+	private short songHeight;
+	private short length;
+	private String title;
+	private File path;
+	private String author;
+	private String description;
+	private float speed;
+	private float delay;
+	private CustomInstrument[] customInstruments;
 
-    public Song(Song other) {
-        this(other.getSpeed(), other.getLayerHashMap(), other.getSongHeight(), other.getLength(), other.getTitle(), other.getAuthor(), other.getDescription(), other.getPath(), other.getCustomInstruments());
-    }
-    
-    public Song(float speed, HashMap<Integer, Layer> layerHashMap,
-                short songHeight, final short length, String title, String author,
-                String description, File path) {
-        this(speed, layerHashMap, songHeight, length, title, author, description, path, new CustomInstrument[0]);
-    }
+	public Song(Song other) {
+		this(other.getSpeed(), other.getLayerHashMap(), other.getSongHeight(), 
+				other.getLength(), other.getTitle(), other.getAuthor(), 
+				other.getDescription(), other.getPath(), other.getCustomInstruments());
+	}
 
-	public Song(float speed, HashMap<Integer, Layer> layerHashMap, short songHeight, final short length, String title, String author, String description, File path, CustomInstrument[] customInstrument) {
-    	this.speed = speed;
-        delay = 20 / speed;
-        this.layerHashMap = layerHashMap;
-        this.songHeight = songHeight;
-        this.length = length;
-        this.title = title;
-        this.author = author;
-        this.description = description;
-        this.path = path;
-        this.customInstrument = customInstrument;
-    }
+	public Song(float speed, HashMap<Integer, Layer> layerHashMap,
+			short songHeight, final short length, String title, String author,
+			String description, File path) {
+		this(speed, layerHashMap, songHeight, length, title, author, description, path, new CustomInstrument[0]);
+	}
 
-    public HashMap<Integer, Layer> getLayerHashMap() {
-        return layerHashMap;
-    }
+	public Song(float speed, HashMap<Integer, Layer> layerHashMap, 
+			short songHeight, final short length, String title, String author, 
+			String description, File path, CustomInstrument[] customInstruments) {
+		this.speed = speed;
+		delay = 20 / speed;
+		this.layerHashMap = layerHashMap;
+		this.songHeight = songHeight;
+		this.length = length;
+		this.title = title;
+		this.author = author;
+		this.description = description;
+		this.path = path;
+		this.customInstruments = customInstruments;
+	}
 
-    public short getSongHeight() {
-        return songHeight;
-    }
+	public HashMap<Integer, Layer> getLayerHashMap() {
+		return layerHashMap;
+	}
 
-    public short getLength() {
-        return length;
-    }
+	public short getSongHeight() {
+		return songHeight;
+	}
 
-    public String getTitle() {
-        return title;
-    }
+	public short getLength() {
+		return length;
+	}
 
-    public String getAuthor() {
-        return author;
-    }
+	public String getTitle() {
+		return title;
+	}
 
-    public File getPath() {
-        return path;
-    }
+	public String getAuthor() {
+		return author;
+	}
 
-    public String getDescription() {
-        return description;
-    }
+	public File getPath() {
+		return path;
+	}
 
-    public float getSpeed() {
-        return speed;
-    }
+	public String getDescription() {
+		return description;
+	}
 
-    public float getDelay() {
-        return delay;
-    }
-    
-    public CustomInstrument[] getCustomInstruments(){
-    	return customInstrument;
-    }
+	public float getSpeed() {
+		return speed;
+	}
+
+	public float getDelay() {
+		return delay;
+	}
+
+	public CustomInstrument[] getCustomInstruments() {
+		return customInstruments;
+	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Song.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Song.java
@@ -3,7 +3,11 @@ package com.xxmicloxx.NoteBlockAPI;
 import java.io.File;
 import java.util.HashMap;
 
-public class Song {
+/**
+ * Represents a Note Block Studio project
+ *
+ */
+public class Song implements Cloneable {
 
 	private HashMap<Integer, Layer> layerHashMap = new HashMap<Integer, Layer>();
 	private short songHeight;
@@ -43,44 +47,90 @@ public class Song {
 		this.customInstruments = customInstruments;
 	}
 
+	/**
+	 * Gets all Layers in this Song and their index
+	 * @return HashMap of Layers and their index
+	 */
 	public HashMap<Integer, Layer> getLayerHashMap() {
 		return layerHashMap;
 	}
 
+	/**
+	 * Gets the Song's height
+	 * @return Song height
+	 */
 	public short getSongHeight() {
 		return songHeight;
 	}
 
+	/**
+	 * Gets the length in ticks of this Song
+	 * @return length of this Song
+	 */
 	public short getLength() {
 		return length;
 	}
 
+	/**
+	 * Gets the title / name of this Song
+	 * @return title of the Song
+	 */
 	public String getTitle() {
 		return title;
 	}
 
+	/**
+	 * Gets the author of the Song
+	 * @return author
+	 */
 	public String getAuthor() {
 		return author;
 	}
 
+	/**
+	 * Returns the File from which this Song is sourced
+	 * @return file of this Song
+	 */
 	public File getPath() {
 		return path;
 	}
 
+	/**
+	 * Gets the description of this Song
+	 * @return description
+	 */
 	public String getDescription() {
 		return description;
 	}
 
+	/**
+	 * Gets the speed (ticks per second) of this Song
+	 * @return
+	 */
 	public float getSpeed() {
 		return speed;
 	}
 
+	/**
+	 * Gets the delay of this Song
+	 * @return delay
+	 */
 	public float getDelay() {
 		return delay;
 	}
 
+	/**
+	 * Gets the CustomInstruments made for this Song
+	 * @see CustomInstrument
+	 * @return array of CustomInstruments
+	 */
 	public CustomInstrument[] getCustomInstruments() {
 		return customInstruments;
+	}
+
+	@Override
+	public Song clone() {
+		return new Song(this);
 	}
 
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/SongDestroyingEvent.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/SongDestroyingEvent.java
@@ -4,6 +4,11 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Called whenever a Song is destroyed
+ * @see SongPlayer
+ *
+ */
 public class SongDestroyingEvent extends Event implements Cancellable {
 
 	private static final HandlerList handlers = new HandlerList();

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/SongDestroyingEvent.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/SongDestroyingEvent.java
@@ -6,33 +6,34 @@ import org.bukkit.event.HandlerList;
 
 public class SongDestroyingEvent extends Event implements Cancellable {
 
-    private static final HandlerList handlers = new HandlerList();
-    private SongPlayer song;
-    private boolean cancelled = false;
+	private static final HandlerList handlers = new HandlerList();
+	private SongPlayer song;
+	private boolean cancelled = false;
 
-    public SongDestroyingEvent(SongPlayer song) {
-        this.song = song;
-    }
+	public SongDestroyingEvent(SongPlayer song) {
+		this.song = song;
+	}
 
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
 
-    public SongPlayer getSongPlayer() {
-        return song;
-    }
+	public SongPlayer getSongPlayer() {
+		return song;
+	}
 
-    public HandlerList getHandlers() {
-        return handlers;
-    }
+	public HandlerList getHandlers() {
+		return handlers;
+	}
 
-    @Override
-    public boolean isCancelled() {
-        return cancelled;
-    }
+	@Override
+	public boolean isCancelled() {
+		return cancelled;
+	}
 
-    @Override
-    public void setCancelled(boolean arg0) {
-        cancelled = arg0;
-    }
+	@Override
+	public void setCancelled(boolean arg0) {
+		cancelled = arg0;
+	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/SongEndEvent.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/SongEndEvent.java
@@ -3,6 +3,12 @@ package com.xxmicloxx.NoteBlockAPI;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Called when a Song ends
+ * or when no players are listening and auto destroy is enabled
+ * @see SongPlayer
+ *
+ */
 public class SongEndEvent extends Event {
 
 	private static final HandlerList handlers = new HandlerList();

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/SongEndEvent.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/SongEndEvent.java
@@ -5,22 +5,23 @@ import org.bukkit.event.HandlerList;
 
 public class SongEndEvent extends Event {
 
-    private static final HandlerList handlers = new HandlerList();
-    private SongPlayer song;
+	private static final HandlerList handlers = new HandlerList();
+	private SongPlayer song;
 
-    public SongEndEvent(SongPlayer song) {
-        this.song = song;
-    }
+	public SongEndEvent(SongPlayer song) {
+		this.song = song;
+	}
 
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
 
-    public SongPlayer getSongPlayer() {
-        return song;
-    }
+	public SongPlayer getSongPlayer() {
+		return song;
+	}
 
-    public HandlerList getHandlers() {
-        return handlers;
-    }
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/SongPlayer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/SongPlayer.java
@@ -3,31 +3,45 @@ package com.xxmicloxx.NoteBlockAPI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
+/**
+ * Plays a Song for a list of Players
+ *
+ */
 public abstract class SongPlayer {
 
 	protected Song song;
+
 	protected boolean playing = false;
 	protected short tick = -1;
-	protected Map<String, Boolean> playerList = Collections.synchronizedMap(new HashMap<String, Boolean>());
+	protected Map<UUID, Boolean> playerList = Collections.synchronizedMap(new HashMap<UUID, Boolean>());
+
 	protected boolean autoDestroy = false;
 	protected boolean destroyed = false;
+
 	protected Thread playerThread;
-	protected byte fadeTarget = 100;
+
 	protected byte volume = 100;
 	protected byte fadeStart = volume;
+	protected byte fadeTarget = 100;
 	protected int fadeDuration = 60;
 	protected int fadeDone = 0;
 	protected FadeType fadeType = FadeType.FADE_LINEAR;
+
 	private final Lock lock = new ReentrantLock();
+
 	protected NoteBlockPlayerMain plugin;
+
 	protected SoundCategory soundCategory;
 
 	public SongPlayer(Song song) {
@@ -41,57 +55,102 @@ public abstract class SongPlayer {
 		start();
 	}
 
+	/**
+	 * Gets the FadeType for this SongPlayer (unused)
+	 * @return FadeType
+	 */
 	public FadeType getFadeType() {
 		return fadeType;
 	}
 
+	/**
+	 * Sets the FadeType for this SongPlayer
+	 * @param fadeType
+	 */
 	public void setFadeType(FadeType fadeType) {
 		this.fadeType = fadeType;
 	}
 
+	/**
+	 * Target volume for fade
+	 * @return byte representing fade target
+	 */
 	public byte getFadeTarget() {
 		return fadeTarget;
 	}
 
+	/**
+	 * Set target volume for fade
+	 * @param fadeTarget
+	 */
 	public void setFadeTarget(byte fadeTarget) {
 		this.fadeTarget = fadeTarget;
 	}
 
+	/**
+	 * Gets the starting time for the fade
+	 * @return
+	 */
 	public byte getFadeStart() {
 		return fadeStart;
 	}
 
+	/**
+	 * Sets the starting time for the fade
+	 * @param fadeStart
+	 */
 	public void setFadeStart(byte fadeStart) {
 		this.fadeStart = fadeStart;
 	}
 
+	/**
+	 * Gets the duration of the fade
+	 * @return duration of the fade
+	 */
 	public int getFadeDuration() {
 		return fadeDuration;
 	}
 
+	/**
+	 * Sets the duration of the fade
+	 * @param fadeDuration
+	 */
 	public void setFadeDuration(int fadeDuration) {
 		this.fadeDuration = fadeDuration;
 	}
 
+	/**
+	 * Gets the tick when fade will be finished
+	 * @return tick
+	 */
 	public int getFadeDone() {
 		return fadeDone;
 	}
 
+	/**
+	 * Sets the tick when fade will be finished
+	 * @param fadeDone
+	 */
 	public void setFadeDone(int fadeDone) {
 		this.fadeDone = fadeDone;
 	}
 
+	/**
+	 * Calculates the fade at the given time and sets the current volume
+	 */
 	protected void calculateFade() {
 		if (fadeDone == fadeDuration) {
 			return; // no fade today
 		}
 		double targetVolume = Interpolator.interpLinear(
 				new double[]{0, fadeStart, fadeDuration, fadeTarget}, fadeDone);
-		setVolume((byte)targetVolume);
+		setVolume((byte) targetVolume);
 		fadeDone++;
 	}
 
-	@SuppressWarnings("deprecation")
+	/**
+	 * Starts this SongPlayer
+	 */
 	private void start() {
 		plugin.doAsync(() -> {
 			while (!destroyed) {
@@ -117,8 +176,8 @@ public abstract class SongPlayer {
 						}
 
 						plugin.doSync(() -> {
-							for (String string : playerList.keySet()) {
-								Player player = Bukkit.getPlayerExact(string);
+							for (UUID uuid : playerList.keySet()) {
+								Player player = Bukkit.getPlayer(uuid);
 								if (player == null) {
 									// offline...
 									continue;
@@ -150,30 +209,56 @@ public abstract class SongPlayer {
 		});
 	}
 
+	/**
+	 * Gets list of current Player usernames listening to this SongPlayer
+	 * @return list of Player usernames
+	 * @Deprecated use getPlayerUUIDs
+	 */
 	public List<String> getPlayerList() {
-		List<String> list = new ArrayList<String>();
-		list.addAll(playerList.keySet());
+		List<String> list = new ArrayList<>();
+		for (UUID uuid : playerList.keySet()) {
+			list.add(Bukkit.getPlayer(uuid).getName());
+		}
 		return Collections.unmodifiableList(list);
 	}
 
+	/**
+	 * Gets list of current Player usernames listening to this SongPlayer
+	 * @return list of Player usernames
+	 */
+	public Set<UUID> getPlayerUUIDs() {
+		Set<UUID> uuids = new HashSet<>();
+		uuids.addAll(playerList.keySet());
+		return Collections.unmodifiableSet(uuids);
+	}
+
+	/**
+	 * Adds a Player to the list of Players listening to this SongPlayer
+	 * @param player
+	 */
 	public void addPlayer(Player player) {
 		lock.lock();
 		try {
-			if (!playerList.containsKey(player.getName())) {
-				playerList.put(player.getName(), false);
+			if (!playerList.containsKey(player.getUniqueId())) {
+				playerList.put(player.getUniqueId(), false);
 				ArrayList<SongPlayer> songs = NoteBlockPlayerMain.plugin.playingSongs
-						.get(player.getName());
+						.get(player.getUniqueId());
 				if (songs == null) {
 					songs = new ArrayList<SongPlayer>();
 				}
 				songs.add(this);
-				NoteBlockPlayerMain.plugin.playingSongs.put(player.getName(), songs);
+				NoteBlockPlayerMain.plugin.playingSongs.put(player.getUniqueId(), songs);
 			}
 		} finally {
 			lock.unlock();
 		}
 	}
 
+	/**
+	 * Returns whether the SongPlayer is set to destroy itself when no one is listening 
+	 * or when the Song ends
+	 * @return if autoDestroy is enabled
+	 */
 	public boolean getAutoDestroy() {
 		lock.lock();
 		try {
@@ -183,16 +268,25 @@ public abstract class SongPlayer {
 		}
 	}
 
-	public void setAutoDestroy(boolean value) {
+	/**
+	 * Sets autoDestroy
+	 * @param if autoDestroy is enabled
+	 */
+	public void setAutoDestroy(boolean autoDestroy) {
 		lock.lock();
 		try {
-			autoDestroy = value;
+			this.autoDestroy = autoDestroy;
 		} finally {
 			lock.unlock();
 		}
 	}
 
-	public abstract void playTick(Player p, int tick);
+	/**
+	 * Plays the Song for the specific player
+	 * @param player to play this SongPlayer for
+	 * @param tick to play at
+	 */
+	public abstract void playTick(Player player, int tick);
 
 	public void destroy() {
 		lock.lock();
@@ -211,10 +305,18 @@ public abstract class SongPlayer {
 		}
 	}
 
+	/**
+	 * Returns whether the SongPlayer is actively playing
+	 * @return is playing
+	 */
 	public boolean isPlaying() {
 		return playing;
 	}
 
+	/**
+	 * Sets whether the SongPlayer is playing
+	 * @param playing
+	 */
 	public void setPlaying(boolean playing) {
 		this.playing = playing;
 		if (!playing) {
@@ -223,25 +325,37 @@ public abstract class SongPlayer {
 		}
 	}
 
+	/**
+	 * Gets the current tick of this SongPlayer
+	 * @return
+	 */
 	public short getTick() {
 		return tick;
 	}
 
+	/**
+	 * Sets the current tick of this SongPlayer
+	 * @param tick
+	 */
 	public void setTick(short tick) {
 		this.tick = tick;
 	}
 
-	public void removePlayer(Player p) {
+	/**
+	 * Removes a player from this SongPlayer
+	 * @param player to remove
+	 */
+	public void removePlayer(Player player) {
 		lock.lock();
 		try {
-			playerList.remove(p.getName());
-			if (NoteBlockPlayerMain.plugin.playingSongs.get(p.getName()) == null) {
+			playerList.remove(player.getUniqueId());
+			if (NoteBlockPlayerMain.plugin.playingSongs.get(player.getUniqueId()) == null) {
 				return;
 			}
-			ArrayList<SongPlayer> songs = new ArrayList<SongPlayer>(
-					NoteBlockPlayerMain.plugin.playingSongs.get(p.getName()));
+			ArrayList<SongPlayer> songs = new ArrayList<>(
+					NoteBlockPlayerMain.plugin.playingSongs.get(player.getUniqueId()));
 			songs.remove(this);
-			NoteBlockPlayerMain.plugin.playingSongs.put(p.getName(), songs);
+			NoteBlockPlayerMain.plugin.playingSongs.put(player.getUniqueId(), songs);
 			if (playerList.isEmpty() && autoDestroy) {
 				SongEndEvent event = new SongEndEvent(this);
 				Bukkit.getPluginManager().callEvent(event);
@@ -252,23 +366,45 @@ public abstract class SongPlayer {
 		}
 	}
 
+	/**
+	 * Gets the current volume of this SongPlayer
+	 * @return volume (0-100)
+	 */
 	public byte getVolume() {
 		return volume;
 	}
 
+	/**
+	 * Sets the current volume of this SongPlayer
+	 * @param volume (0-100)
+	 */
 	public void setVolume(byte volume) {
 		this.volume = volume;
 	}
 
+	/**
+	 * Gets the Song being played by this SongPlayer
+	 * @return
+	 */
 	public Song getSong() {
 		return song;
 	}
 
+	/**
+	 * Gets the SoundCategory of this SongPlayer
+	 * @see SoundCategory
+	 * @return SoundCategory of this SongPlayer
+	 */
 	public SoundCategory getCategory() {
 		return soundCategory;
 	}
 
+	/**
+	 * Sets the SoundCategory for this SongPlayer
+	 * @param soundCategory
+	 */
 	public void setCategory(SoundCategory soundCategory) {
 		this.soundCategory = soundCategory;
 	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/SongPlayer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/SongPlayer.java
@@ -13,263 +13,262 @@ import org.bukkit.entity.Player;
 
 public abstract class SongPlayer {
 
-    protected Song song;
-    protected boolean playing = false;
-    protected short tick = -1;
-    protected Map<String, Boolean> playerList = Collections.synchronizedMap(new HashMap<String, Boolean>());
-    protected boolean autoDestroy = false;
-    protected boolean destroyed = false;
-    protected Thread playerThread;
-    protected byte fadeTarget = 100;
-    protected byte volume = 100;
-    protected byte fadeStart = volume;
-    protected int fadeDuration = 60;
-    protected int fadeDone = 0;
-    protected FadeType fadeType = FadeType.FADE_LINEAR;
-    private final Lock lock = new ReentrantLock();
-    protected NoteBlockPlayerMain plugin;
-    protected SoundCategory soundCategory;
-    
-    public SongPlayer(Song song) {
-    	this(song, SoundCategory.MASTER);
-    }
+	protected Song song;
+	protected boolean playing = false;
+	protected short tick = -1;
+	protected Map<String, Boolean> playerList = Collections.synchronizedMap(new HashMap<String, Boolean>());
+	protected boolean autoDestroy = false;
+	protected boolean destroyed = false;
+	protected Thread playerThread;
+	protected byte fadeTarget = 100;
+	protected byte volume = 100;
+	protected byte fadeStart = volume;
+	protected int fadeDuration = 60;
+	protected int fadeDone = 0;
+	protected FadeType fadeType = FadeType.FADE_LINEAR;
+	private final Lock lock = new ReentrantLock();
+	protected NoteBlockPlayerMain plugin;
+	protected SoundCategory soundCategory;
 
-    public SongPlayer(Song song, SoundCategory soundCategory) {
-        this.song = song;
-        this.soundCategory = soundCategory;
-        plugin = NoteBlockPlayerMain.plugin;
-        start();
-    }
+	public SongPlayer(Song song) {
+		this(song, SoundCategory.MASTER);
+	}
 
-    public FadeType getFadeType() {
-        return fadeType;
-    }
+	public SongPlayer(Song song, SoundCategory soundCategory) {
+		this.song = song;
+		this.soundCategory = soundCategory;
+		plugin = NoteBlockPlayerMain.plugin;
+		start();
+	}
 
-    public void setFadeType(FadeType fadeType) {
-        this.fadeType = fadeType;
-    }
+	public FadeType getFadeType() {
+		return fadeType;
+	}
 
-    public byte getFadeTarget() {
-        return fadeTarget;
-    }
+	public void setFadeType(FadeType fadeType) {
+		this.fadeType = fadeType;
+	}
 
-    public void setFadeTarget(byte fadeTarget) {
-        this.fadeTarget = fadeTarget;
-    }
+	public byte getFadeTarget() {
+		return fadeTarget;
+	}
 
-    public byte getFadeStart() {
-        return fadeStart;
-    }
+	public void setFadeTarget(byte fadeTarget) {
+		this.fadeTarget = fadeTarget;
+	}
 
-    public void setFadeStart(byte fadeStart) {
-        this.fadeStart = fadeStart;
-    }
+	public byte getFadeStart() {
+		return fadeStart;
+	}
 
-    public int getFadeDuration() {
-        return fadeDuration;
-    }
+	public void setFadeStart(byte fadeStart) {
+		this.fadeStart = fadeStart;
+	}
 
-    public void setFadeDuration(int fadeDuration) {
-        this.fadeDuration = fadeDuration;
-    }
+	public int getFadeDuration() {
+		return fadeDuration;
+	}
 
-    public int getFadeDone() {
-        return fadeDone;
-    }
+	public void setFadeDuration(int fadeDuration) {
+		this.fadeDuration = fadeDuration;
+	}
 
-    public void setFadeDone(int fadeDone) {
-        this.fadeDone = fadeDone;
-    }
+	public int getFadeDone() {
+		return fadeDone;
+	}
 
-    protected void calculateFade() {
-        if (fadeDone == fadeDuration) {
-            return; // no fade today
-        }
-        double targetVolume = Interpolator.interpLinear(new double[]{0, fadeStart, fadeDuration, fadeTarget}, fadeDone);
-        setVolume((byte)targetVolume);
-        fadeDone++;
-    }
+	public void setFadeDone(int fadeDone) {
+		this.fadeDone = fadeDone;
+	}
 
-    @SuppressWarnings("deprecation")
+	protected void calculateFade() {
+		if (fadeDone == fadeDuration) {
+			return; // no fade today
+		}
+		double targetVolume = Interpolator.interpLinear(
+				new double[]{0, fadeStart, fadeDuration, fadeTarget}, fadeDone);
+		setVolume((byte)targetVolume);
+		fadeDone++;
+	}
+
+	@SuppressWarnings("deprecation")
 	private void start() {
-    	plugin.doAsync(() -> {
-            while (!destroyed) {
-                long startTime = System.currentTimeMillis();
-                lock.lock();
-                try {
-                	if (destroyed || NoteBlockPlayerMain.plugin.isDisabling()){
-                    	break;
-                    }
-                	
-                    if (playing) {
-                        calculateFade();
-                        tick++;
-                        if (tick > song.getLength()) {
-                            playing = false;
-                            tick = -1;
-                            SongEndEvent event = new SongEndEvent(SongPlayer.this);
-                            plugin.doSync(() -> Bukkit.getPluginManager().callEvent(event));
-                            if (autoDestroy) {
-                                destroy();
-                            }
-                            return;
-                        }
-                        
-                        plugin.doSync(() -> {
-	                        for (String s : playerList.keySet()) {
-	                            Player p = Bukkit.getPlayerExact(s);
-	                            if (p == null) {
-	                                // offline...
-	                                continue;
-	                            }
-	                            playTick(p, tick);
-	                        }
-                        });
-                    }
-                } catch (Exception e) {
-                    e.printStackTrace();
-                } finally {
-                    lock.unlock();
-                }
-                
-                if (destroyed){
-                	break;
-                }
-                
-                long duration = System.currentTimeMillis() - startTime;
-                float delayMillis = song.getDelay() * 50;
-                if (duration < delayMillis) {
-                    try {
-                        Thread.sleep((long) (delayMillis - duration));
-                    } catch (InterruptedException e) {
-                        // do nothing
-                    }
-                }
-            }
-        });
-    }
+		plugin.doAsync(() -> {
+			while (!destroyed) {
+				long startTime = System.currentTimeMillis();
+				lock.lock();
+				try {
+					if (destroyed || NoteBlockPlayerMain.plugin.isDisabling()){
+						break;
+					}
 
-    public List<String> getPlayerList() {
-    	List<String> list = new ArrayList<String>();
-    	list.addAll(playerList.keySet());
-        return Collections.unmodifiableList(list);
-    }
+					if (playing) {
+						calculateFade();
+						tick++;
+						if (tick > song.getLength()) {
+							playing = false;
+							tick = -1;
+							SongEndEvent event = new SongEndEvent(SongPlayer.this);
+							plugin.doSync(() -> Bukkit.getPluginManager().callEvent(event));
+							if (autoDestroy) {
+								destroy();
+							}
+							return;
+						}
 
-    public void addPlayer(Player p) {
-       lock.lock();
-       try{
-            if (!playerList.containsKey(p.getName())) {
-                playerList.put(p.getName(), false);
-                ArrayList<SongPlayer> songs = NoteBlockPlayerMain.plugin.playingSongs
-                        .get(p.getName());
-                if (songs == null) {
-                    songs = new ArrayList<SongPlayer>();
-                }
-                songs.add(this);
-                NoteBlockPlayerMain.plugin.playingSongs.put(p.getName(), songs);
-            }
-        } finally {
+						plugin.doSync(() -> {
+							for (String string : playerList.keySet()) {
+								Player player = Bukkit.getPlayerExact(string);
+								if (player == null) {
+									// offline...
+									continue;
+								}
+								playTick(player, tick);
+							}
+						});
+					}
+				} catch (Exception e) {
+					e.printStackTrace();
+				} finally {
+					lock.unlock();
+				}
+
+				if (destroyed) {
+					break;
+				}
+
+				long duration = System.currentTimeMillis() - startTime;
+				float delayMillis = song.getDelay() * 50;
+				if (duration < delayMillis) {
+					try {
+						Thread.sleep((long) (delayMillis - duration));
+					} catch (InterruptedException e) {
+						// do nothing
+					}
+				}
+			}
+		});
+	}
+
+	public List<String> getPlayerList() {
+		List<String> list = new ArrayList<String>();
+		list.addAll(playerList.keySet());
+		return Collections.unmodifiableList(list);
+	}
+
+	public void addPlayer(Player player) {
+		lock.lock();
+		try {
+			if (!playerList.containsKey(player.getName())) {
+				playerList.put(player.getName(), false);
+				ArrayList<SongPlayer> songs = NoteBlockPlayerMain.plugin.playingSongs
+						.get(player.getName());
+				if (songs == null) {
+					songs = new ArrayList<SongPlayer>();
+				}
+				songs.add(this);
+				NoteBlockPlayerMain.plugin.playingSongs.put(player.getName(), songs);
+			}
+		} finally {
 			lock.unlock();
 		}
-    }
+	}
 
-    
-    
-    public boolean getAutoDestroy() {
-        lock.lock();
-        try {
-            return autoDestroy;
-        } finally {
+	public boolean getAutoDestroy() {
+		lock.lock();
+		try {
+			return autoDestroy;
+		} finally {
 			lock.unlock();
 		}
-    }
+	}
 
-    public void setAutoDestroy(boolean value) {
-    	lock.lock();
-        try {
-            autoDestroy = value;
-        } finally {
+	public void setAutoDestroy(boolean value) {
+		lock.lock();
+		try {
+			autoDestroy = value;
+		} finally {
 			lock.unlock();
 		}
-    }
+	}
 
-    public abstract void playTick(Player p, int tick);
+	public abstract void playTick(Player p, int tick);
 
-    public void destroy() {
-    	lock.lock();
-        try {
-            SongDestroyingEvent event = new SongDestroyingEvent(this);
-            Bukkit.getPluginManager().callEvent(event);
-            //Bukkit.getScheduler().cancelTask(threadId);
-            if (event.isCancelled()) {
-                return;
-            }
-            destroyed = true;
-            playing = false;
-            setTick((short) -1);
-        } finally {
+	public void destroy() {
+		lock.lock();
+		try {
+			SongDestroyingEvent event = new SongDestroyingEvent(this);
+			Bukkit.getPluginManager().callEvent(event);
+			//Bukkit.getScheduler().cancelTask(threadId);
+			if (event.isCancelled()) {
+				return;
+			}
+			destroyed = true;
+			playing = false;
+			setTick((short) -1);
+		} finally {
 			lock.unlock();
 		}
-    }
+	}
 
-    public boolean isPlaying() {
-        return playing;
-    }
+	public boolean isPlaying() {
+		return playing;
+	}
 
-    public void setPlaying(boolean playing) {
-        this.playing = playing;
-        if (!playing) {
-            SongStoppedEvent event = new SongStoppedEvent(this);
-            Bukkit.getPluginManager().callEvent(event);
-        }
-    }
+	public void setPlaying(boolean playing) {
+		this.playing = playing;
+		if (!playing) {
+			SongStoppedEvent event = new SongStoppedEvent(this);
+			Bukkit.getPluginManager().callEvent(event);
+		}
+	}
 
-    public short getTick() {
-        return tick;
-    }
+	public short getTick() {
+		return tick;
+	}
 
-    public void setTick(short tick) {
-    	this.tick = tick;
-    }
+	public void setTick(short tick) {
+		this.tick = tick;
+	}
 
-    public void removePlayer(Player p) {
-    	lock.lock();
-        try {
-            playerList.remove(p.getName());
-            if (NoteBlockPlayerMain.plugin.playingSongs.get(p.getName()) == null) {
-                return;
-            }
-            ArrayList<SongPlayer> songs = new ArrayList<SongPlayer>(
-                    NoteBlockPlayerMain.plugin.playingSongs.get(p.getName()));
-            songs.remove(this);
-            NoteBlockPlayerMain.plugin.playingSongs.put(p.getName(), songs);
-            if (playerList.isEmpty() && autoDestroy) {
-                SongEndEvent event = new SongEndEvent(this);
-                Bukkit.getPluginManager().callEvent(event);
-                destroy();
-            }
-        } finally {
+	public void removePlayer(Player p) {
+		lock.lock();
+		try {
+			playerList.remove(p.getName());
+			if (NoteBlockPlayerMain.plugin.playingSongs.get(p.getName()) == null) {
+				return;
+			}
+			ArrayList<SongPlayer> songs = new ArrayList<SongPlayer>(
+					NoteBlockPlayerMain.plugin.playingSongs.get(p.getName()));
+			songs.remove(this);
+			NoteBlockPlayerMain.plugin.playingSongs.put(p.getName(), songs);
+			if (playerList.isEmpty() && autoDestroy) {
+				SongEndEvent event = new SongEndEvent(this);
+				Bukkit.getPluginManager().callEvent(event);
+				destroy();
+			}
+		} finally {
 			lock.unlock();
 		}
-    }
+	}
 
-    public byte getVolume() {
-        return volume;
-    }
+	public byte getVolume() {
+		return volume;
+	}
 
-    public void setVolume(byte volume) {
-        this.volume = volume;
-    }
+	public void setVolume(byte volume) {
+		this.volume = volume;
+	}
 
-    public Song getSong() {
-        return song;
-    }
+	public Song getSong() {
+		return song;
+	}
 
-    public SoundCategory getCategory() {
-    	return soundCategory;
-    }
+	public SoundCategory getCategory() {
+		return soundCategory;
+	}
 
-    public void setCategory(SoundCategory soundCategory) {
-    	this.soundCategory = soundCategory;
-    }
+	public void setCategory(SoundCategory soundCategory) {
+		this.soundCategory = soundCategory;
+	}
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/SongStoppedEvent.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/SongStoppedEvent.java
@@ -3,6 +3,10 @@ package com.xxmicloxx.NoteBlockAPI;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Called whenever a SongPlayer is stopped
+ *
+ */
 public class SongStoppedEvent extends Event {
 
 	private static final HandlerList handlers = new HandlerList();

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/SongStoppedEvent.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/SongStoppedEvent.java
@@ -5,22 +5,23 @@ import org.bukkit.event.HandlerList;
 
 public class SongStoppedEvent extends Event {
 
-    private static final HandlerList handlers = new HandlerList();
-    private SongPlayer song;
+	private static final HandlerList handlers = new HandlerList();
+	private SongPlayer songPlayer;
 
-    public SongStoppedEvent(SongPlayer song) {
-        this.song = song;
-    }
+	public SongStoppedEvent(SongPlayer songPlayer) {
+		this.songPlayer = songPlayer;
+	}
 
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
 
-    public SongPlayer getSongPlayer() {
-        return song;
-    }
+	public SongPlayer getSongPlayer() {
+		return songPlayer;
+	}
 
-    public HandlerList getHandlers() {
-        return handlers;
-    }
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Sound.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Sound.java
@@ -3,7 +3,7 @@ package com.xxmicloxx.NoteBlockAPI;
 /**
  * Version independent Spigot sounds.
  *
- * Enum mapping to sound names for different
+ * Enum mapping to note names for different
  * Minecraft versions.
  * 
  * @see https://gist.github.com/NiklasEi/7bd0ffd136f8459df0940e4501d47a8a
@@ -30,10 +30,16 @@ public enum Sound {
 		this.versionDependentNames = versionDependentNames;
 	}
 
+	/**
+	 * Attempts to retrieve the org.bukkit.Sound equivalent of a version dependent enum name
+	 * @param bukkitSoundName
+	 * @return org.bukkit.Sound enum
+	 */
 	public static org.bukkit.Sound getFromBukkitName(String bukkitSoundName) {
 		for (Sound sound : values()) {
-			org.bukkit.Sound bukkitSound = sound.getSound();
-			if (bukkitSound != null) return bukkitSound;
+			for (String soundName : sound.versionDependentNames) {
+				if (soundName.equalsIgnoreCase(bukkitSoundName)) return sound.getSound();
+			}
 		}
 		return org.bukkit.Sound.valueOf(bukkitSoundName);
 	}

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/Sound.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/Sound.java
@@ -1,0 +1,66 @@
+package com.xxmicloxx.NoteBlockAPI;
+
+/**
+ * Version independent Spigot sounds.
+ *
+ * Enum mapping to sound names for different
+ * Minecraft versions.
+ * 
+ * @see https://gist.github.com/NiklasEi/7bd0ffd136f8459df0940e4501d47a8a
+ * @author NiklasEi
+ */
+public enum Sound {
+
+	NOTE_BASS_DRUM("NOTE_BASS_DRUM", "BLOCK_NOTE_BASEDRUM", "BLOCK_NOTE_BLOCK_BASEDRUM"),
+	NOTE_BASS("NOTE_BASS", "BLOCK_NOTE_BASS", "BLOCK_NOTE_BLOCK_BASS"),
+	NOTE_BELL("NOTE_BELL", "BLOCK_NOTE_BELL", "BLOCK_NOTE_BLOCK_BELL"),
+	NOTE_CHIME("NOTE_CHIME", "BLOCK_NOTE_CHIME", "BLOCK_NOTE_BLOCK_CHIME"),
+	NOTE_FLUTE("NOTE_FLUTE", "BLOCK_NOTE_FLUTE", "BLOCK_NOTE_BLOCK_FLUTE"),
+	NOTE_BASS_GUITAR("NOTE_BASS_GUITAR", "BLOCK_NOTE_GUITAR", "BLOCK_NOTE_BLOCK_GUITAR"),
+	NOTE_PIANO("NOTE_PIANO", "BLOCK_NOTE_HARP", "BLOCK_NOTE_BLOCK_HARP"),
+	NOTE_STICKS("NOTE_STICKS", "BLOCK_NOTE_HAT", "BLOCK_NOTE_BLOCK_HAT"),
+	NOTE_PLING("NOTE_PLING", "BLOCK_NOTE_PLING", "BLOCK_NOTE_BLOCK_PLING"),
+	NOTE_SNARE_DRUM("NOTE_SNARE_DRUM", "BLOCK_NOTE_SNARE", "BLOCK_NOTE_BLOCK_SNARE"),
+	NOTE_XYLOPHONE("NOTE_XYLOPHONE", "BLOCK_NOTE_XYLOPHONE", "BLOCK_NOTE_BLOCK_XYLOPHONE");
+
+	private String[] versionDependentNames;
+	private org.bukkit.Sound cached = null;
+
+	Sound(String... versionDependentNames) {
+		this.versionDependentNames = versionDependentNames;
+	}
+
+	public static org.bukkit.Sound getFromBukkitName(String bukkitSoundName) {
+		for (Sound sound : values()) {
+			org.bukkit.Sound bukkitSound = sound.getSound();
+			if (bukkitSound != null) return bukkitSound;
+		}
+		return org.bukkit.Sound.valueOf(bukkitSoundName);
+	}
+
+	private org.bukkit.Sound getSound() {
+		if (cached != null) return cached;
+		for (String name : versionDependentNames) {
+			try {
+				return cached = org.bukkit.Sound.valueOf(name);
+			} catch (IllegalArgumentException ignore2) {
+				// try next
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Get the bukkit sound for current server version
+	 *
+	 * Caches sound on first call
+	 * @return corresponding {@link org.bukkit.Sound}
+	 */
+	public org.bukkit.Sound bukkitSound() {
+		if (getSound() != null) {
+			return getSound();
+		}
+		throw new IllegalArgumentException("Found no valid sound name for " + this.name());
+	}
+
+}

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/SoundCategory.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/SoundCategory.java
@@ -1,14 +1,16 @@
 package com.xxmicloxx.NoteBlockAPI;
 
 public enum SoundCategory {
+
 	MASTER,
-    MUSIC,
-    RECORDS,
-    WEATHER,
-    BLOCKS,
-    HOSTILE,
-    NEUTRAL,
-    PLAYERS,
-    AMBIENT,
-    VOICE;
+	MUSIC,
+	RECORDS,
+	WEATHER,
+	BLOCKS,
+	HOSTILE,
+	NEUTRAL,
+	PLAYERS,
+	AMBIENT,
+	VOICE;
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/SoundCategory.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/SoundCategory.java
@@ -1,5 +1,9 @@
 package com.xxmicloxx.NoteBlockAPI;
 
+/**
+ * @see org.bukkit.SoundCategory
+ *
+ */
 public enum SoundCategory {
 
 	MASTER,

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
-name: NoteBlockAPI
+name: ${name}
 
-main: com.xxmicloxx.NoteBlockAPI.NoteBlockPlayerMain
-version: 1.2.0
+main: ${mainClass}
+version: ${version}
 
 description: a developer interface to play nbs-files ingame
 authors: [xxmicloxx, michidk, koca2000, Luck]


### PR DESCRIPTION
Added 1.13 support and refactored much of the project. Little of the core code was changed; instead, mainly appearance & usability was adjusted for easier usage of the API
* Add "Sound" enum with all current and previous note enum values to more readily handle changes in org.bukkit.Sound
* Add javadocs - I don't know the full extent of this API so I left some things alone
* Deprecate "Instrument", rename to "InstrumentUtils" to avoid confusing the class as an instantiable object
* Rename bunches of variables and methods for less confusion
* Use tabs instead of spaces & use consistent curly brace usage
* Use UUIDs instead of deprecated player name usage
* Use pom for setting version/main class/etc in plugin.yml