### PR TITLE
Bump bstats-bukkit from 1.8 to 2.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>org.bstats</groupId>
 			<artifactId>bstats-bukkit</artifactId>
-			<version>1.8</version>
+			<version>2.1.0</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockAPI.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockAPI.java
@@ -4,6 +4,7 @@ import com.xxmicloxx.NoteBlockAPI.songplayer.SongPlayer;
 import com.xxmicloxx.NoteBlockAPI.utils.MathUtils;
 import com.xxmicloxx.NoteBlockAPI.utils.Updater;
 import org.bstats.bukkit.Metrics;
+import org.bstats.charts.DrilldownPie;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
@@ -173,7 +174,7 @@ public class NoteBlockAPI extends JavaPlugin {
 		            }
 		        }
 		        
-		        metrics.addCustomChart(new Metrics.DrilldownPie("deprecated", () -> {
+		        metrics.addCustomChart(new DrilldownPie("deprecated", () -> {
 			        Map<String, Map<String, Integer>> map = new HashMap<>();
 			        for (Plugin pl : dependentPlugins.keySet()){
 			        	String deprecated = dependentPlugins.get(pl) ? "yes" : "no";


### PR DESCRIPTION
- Add Support for bStats 2.*
- GitHub Action: https://github.com/T0biii/NoteBlockAPI/runs/1905313786

Bumps [bstats-bukkit](https://github.com/Bastian/bStats-Metrics) from 1.8 to 2.2.1.
- [Release notes](https://github.com/Bastian/bStats-Metrics/releases)
- [Commits](https://github.com/Bastian/bStats-Metrics/releases/tag/v2.2.1)

Signed-off-by: dependabot[bot] <support@github.com>Bumps [bstats-bukkit](https://github.com/Bastian/bStats-Metrics) from 1.8 to 2.2.1.
- [Release notes](https://github.com/Bastian/bStats-Metrics/releases)
- [Commits](https://github.com/Bastian/bStats-Metrics/releases/tag/v2.2.1)

Signed-off-by: dependabot[bot] <support@github.com>