### PR TITLE
Fix volume being ignored in NoteblockSongPlayer

### DIFF
--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/songplayer/NoteBlockSongPlayer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/songplayer/NoteBlockSongPlayer.java
@@ -5,7 +5,6 @@ import com.xxmicloxx.NoteBlockAPI.SongPlayer;
 import com.xxmicloxx.NoteBlockAPI.event.PlayerRangeStateChangeEvent;
 import com.xxmicloxx.NoteBlockAPI.model.*;
 import com.xxmicloxx.NoteBlockAPI.utils.CompatibilityUtils;
-import com.xxmicloxx.NoteBlockAPI.utils.InstrumentUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -88,10 +87,6 @@ public class NoteBlockSongPlayer extends RangeSongPlayer {
 			if (note == null) {
 				continue;
 			}
-			int key = note.getKey() - 33;
-
-			while (key < 0) key += 12;
-			while (key > 24) key -= 12;
 
 			float volume = ((layer.getVolume() * (int) this.volume * (int) playerVolume * note.getVelocity()) / 100_00_00_00F)
 					* ((1F / 16F) * getDistance());

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/songplayer/NoteBlockSongPlayer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/songplayer/NoteBlockSongPlayer.java
@@ -93,9 +93,6 @@ public class NoteBlockSongPlayer extends RangeSongPlayer {
 			while (key < 0) key += 12;
 			while (key > 24) key -= 12;
 
-			player.playNote(loc, InstrumentUtils.getBukkitInstrument(note.getInstrument()),
-					new org.bukkit.Note(key));
-
 			float volume = ((layer.getVolume() * (int) this.volume * (int) playerVolume * note.getVelocity()) / 100_00_00_00F)
 					* ((1F / 16F) * getDistance());
 


### PR DESCRIPTION
I don't know why it plays the note twice in the first place, but unlike ChannelMode#play(), Player#playNote() completely ignores the volume so it should be removed.
If this was intentional there should at least be a way to toggle it off.