### PR TITLE
Use own ticker, prevents blocking bukkit threads

### DIFF
--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockAPI.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockAPI.java
@@ -1,6 +1,7 @@
 package com.xxmicloxx.NoteBlockAPI;
 
 import com.xxmicloxx.NoteBlockAPI.songplayer.SongPlayer;
+import com.xxmicloxx.NoteBlockAPI.songplayer.SongTicker;
 import com.xxmicloxx.NoteBlockAPI.utils.MathUtils;
 import com.xxmicloxx.NoteBlockAPI.utils.Updater;
 import org.bstats.bukkit.Metrics;
@@ -135,7 +136,7 @@ public class NoteBlockAPI extends JavaPlugin {
 	@Override
 	public void onEnable() {
 		plugin = this;
-		
+
 		for (Plugin pl : getServer().getPluginManager().getPlugins()){
 			if (pl.getDescription().getDepend().contains("NoteBlockAPI") || pl.getDescription().getSoftDepend().contains("NoteBlockAPI")){
 				dependentPlugins.put(pl, false);
@@ -212,14 +213,11 @@ public class NoteBlockAPI extends JavaPlugin {
 			worker.getThread().interrupt();
 		}
 		NoteBlockPlayerMain.plugin.onDisable();
+		SongTicker.shutdown();
 	}
 
 	public void doSync(Runnable runnable) {
 		getServer().getScheduler().runTask(this, runnable);
-	}
-
-	public void doAsync(Runnable runnable) {
-		getServer().getScheduler().runTaskAsynchronously(this, runnable);
 	}
 
 	public boolean isDisabling() {

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/songplayer/SongTicker.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/songplayer/SongTicker.java
@@ -1,0 +1,42 @@
+package com.xxmicloxx.NoteBlockAPI.songplayer;
+
+import com.xxmicloxx.NoteBlockAPI.utils.NamedThreadFactory;
+import org.bukkit.Bukkit;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class SongTicker {
+    private static final ScheduledExecutorService ticker = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("NoteBlockAPI"));
+    private static final Set<SongPlayer> activeSongPlayers = ConcurrentHashMap.newKeySet();
+
+    static {
+        ticker.scheduleAtFixedRate(SongTicker::tick, 0, 10, TimeUnit.MILLISECONDS);
+    }
+
+    private static void tick() {
+        for (SongPlayer player : activeSongPlayers) {
+            try {
+                player.updateTick();
+            } catch (Exception e) {
+                Bukkit.getLogger().severe("Error updating song player: " + player);
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public static void register(SongPlayer songPlayer) {
+        activeSongPlayers.add(songPlayer);
+    }
+
+    public static void unregister(SongPlayer songPlayer) {
+        activeSongPlayers.remove(songPlayer);
+    }
+
+    public static void shutdown() {
+        ticker.shutdown();
+    }
+}

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/utils/NamedThreadFactory.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/utils/NamedThreadFactory.java
@@ -1,0 +1,20 @@
+package com.xxmicloxx.NoteBlockAPI.utils;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class NamedThreadFactory implements ThreadFactory {
+    private final String baseName;
+    private final AtomicInteger threadCount = new AtomicInteger(1);
+
+    public NamedThreadFactory(String baseName) {
+        this.baseName = baseName;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread thread = new Thread(r);
+        thread.setName(baseName + "-Thread-" + threadCount.getAndIncrement());
+        return thread;
+    }
+}


### PR DESCRIPTION
Use own ticker in its own Thread, prevents blocking Bukkit Threads

 Now start() in SongPlayer adds it to a permanent Thread that loops every 10ms (I found this to be the higher delay without loosing song quality) then I removed the while with Thread.sleep that was in the old start() and changed it to an updateTick() function that checks if next song step should be played if enough time has passed.
 
 This change allows many players to listen to different songs at the same time without blocking bukkit threads preventing other plugin's async functions to fail.