### PR TITLE
Fix pling instrument in 1.8

### DIFF
--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/model/CustomInstrument.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/model/CustomInstrument.java
@@ -21,7 +21,7 @@ public class CustomInstrument {
 		this.index = index;
 		this.name = name;
 		this.soundFileName = soundFileName.replaceAll(".ogg", "");
-		if (this.soundFileName.equalsIgnoreCase("pling")){
+		if (this.soundFileName.equalsIgnoreCase("pling") || this.soundFileName.equalsIgnoreCase("block.note_block.pling")) {
 			this.sound = Sound.NOTE_PLING.bukkitSound();
 		}
 	}


### PR DESCRIPTION
This fixes the pling (15) instrument in 1.8 (and possibly -1.11) servers for 1.8-1.11 clients, adapting the custom instrument created for compatibility to use `Sound.NOTE_PLING`.

Prior to the fix, 1.8 clients would show this warning and play no sound when sent a pling instrument from NBS files:
```
Unable to play unknown soundEvent: minecraft:block.note_block.pling
```