### PR TITLE
fix: avoid reflective listener scans for dependency metrics

### DIFF
--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockAPI.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockAPI.java
@@ -15,8 +15,6 @@ import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.scheduler.BukkitWorker;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -151,27 +149,18 @@ public class NoteBlockAPI extends JavaPlugin {
 			
 			@Override
 			public void run() {
-				Plugin[] plugins = getServer().getPluginManager().getPlugins();
-		        Type[] types = new Type[]{PlayerRangeStateChangeEvent.class, SongDestroyingEvent.class, SongEndEvent.class, SongStoppedEvent.class };
-		        for (Plugin plugin : plugins) {
-		            ArrayList<RegisteredListener> rls = HandlerList.getRegisteredListeners(plugin);
-		            for (RegisteredListener rl : rls) {
-		                Method[] methods = rl.getListener().getClass().getDeclaredMethods();
-		                for (Method m : methods) {
-		                    Type[] params = m.getParameterTypes();
-		                    param:
-		                    for (Type paramType : params) {
-		                    	for (Type type : types){
-		                    		if (paramType.equals(type)) {
-		                    			dependentPlugins.put(plugin, true);
-		                    			break param;
-		                    		}
-		                    	}
-		                    }
-		                }
-
-		            }
-		        }
+				for (RegisteredListener rl : PlayerRangeStateChangeEvent.getHandlerList().getRegisteredListeners()) {
+					dependentPlugins.put(rl.getPlugin(), true);
+				}
+				for (RegisteredListener rl : SongDestroyingEvent.getHandlerList().getRegisteredListeners()) {
+					dependentPlugins.put(rl.getPlugin(), true);
+				}
+				for (RegisteredListener rl : SongEndEvent.getHandlerList().getRegisteredListeners()) {
+					dependentPlugins.put(rl.getPlugin(), true);
+				}
+				for (RegisteredListener rl : SongStoppedEvent.getHandlerList().getRegisteredListeners()) {
+					dependentPlugins.put(rl.getPlugin(), true);
+				}
 		        
 		        metrics.addCustomChart(new DrilldownPie("deprecated", () -> {
 			        Map<String, Map<String, Integer>> map = new HashMap<>();


### PR DESCRIPTION
 ## Summary

  Replace the reflective listener scan in `NoteBlockAPI#onEnable()` with direct event handler list inspection for NoteBlockAPI events.

  ## Problem

  The previous implementation iterated over all registered listeners of all plugins and called:

  - `rl.getListener().getClass().getDeclaredMethods()`

  This can fail in environments that restrict reflection access to protected/internal plugin classes (e.g. custom security managers / class access guards), causing plugin startup warnings or exceptions.

  ## Changes

  Instead of scanning listener classes and method parameter types via reflection, this patch now checks listeners directly from the handler lists of NoteBlockAPI events:

  - `PlayerRangeStateChangeEvent`
  - `SongDestroyingEvent`
  - `SongEndEvent`
  - `SongStoppedEvent`

  Each registered listener's owning plugin is marked as dependent.

  ## Why this is better

  - avoids reflective access to foreign plugin listener classes
  - no dependency on method signatures / parameter scanning
  - uses Bukkit/Paper's event registration API directly
  - simpler and more robust

  ## Compatibility

  Behavior is preserved for the metrics use case (`deprecated` chart), while removing the reflection-based scan.