### PR TITLE
Fix negative fine pitch across octave boundaries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
 			<version>3.0.0</version>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/utils/NoteUtils.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/utils/NoteUtils.java
@@ -44,7 +44,7 @@ public class NoteUtils {
     public static float getPitchInOctave(byte key, short pitch) {
         // Apply pitch to key
         key = applyPitchToKey(key, pitch);
-        pitch %= 100;
+        pitch = (short) Math.floorMod(pitch, 100);
 
         // -15 base_-2
         // 9 base_-1
@@ -62,7 +62,7 @@ public class NoteUtils {
     }
 
     public static byte applyPitchToKey(byte key, short pitch) {
-        key += pitch / 100;
+        key += Math.floorDiv(pitch, 100);
         return key;
     }
 

--- a/src/test/java/com/xxmicloxx/NoteBlockAPI/utils/NoteUtilsTest.java
+++ b/src/test/java/com/xxmicloxx/NoteBlockAPI/utils/NoteUtilsTest.java
@@ -1,0 +1,24 @@
+package com.xxmicloxx.NoteBlockAPI.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class NoteUtilsTest {
+
+	@Test
+	public void negativeFinePitchMovesToPreviousKeyWithoutIndexUnderflow() {
+		assertEquals(32, NoteUtils.applyPitchToKey((byte) 33, (short) -30));
+		assertEquals(expectedPitch(2370), NoteUtils.getPitchInOctave((byte) 33, (short) -30), 0.000001f);
+	}
+
+	@Test
+	public void negativeFinePitchSelectsThePreviousOctaveSample() {
+		assertEquals("test_-1", InstrumentUtils.warpNameOutOfRange("test", (byte) 33, (short) -30));
+		assertEquals("test", InstrumentUtils.warpNameOutOfRange("test", (byte) 57, (short) -30));
+	}
+
+	private float expectedPitch(int index) {
+		return (float) Math.pow(2, (index - 1200d) / 1200d);
+	}
+}


### PR DESCRIPTION
## Summary

- normalize negative fine-pitch values with floor division and floor modulus
- select the previous octave sample when a negative cent offset crosses an octave boundary
- add regression tests for pitch calculation and resource-pack sound selection

## Root cause

`NoteUtils.getPitchInOctave` split the fine-pitch value using Java integer division and remainder:

```java
key += pitch / 100;
pitch %= 100;
```

Java truncates integer division toward zero and keeps a negative remainder. For example, a note at key 33 with a -30 cent offset remained at key 33 with a remainder of -30. At the lower edge of that octave sample, this produced `pitches[-30]` and threw an `ArrayIndexOutOfBoundsException`.

The exception propagated out of note playback and aborted the rest of that song tick, causing audible missing notes whenever 10-octave playback was enabled.

## Fix

Using `Math.floorDiv` and `Math.floorMod` represents the same note as key 32 with a +70 cent offset. This selects the previous octave sample and preserves the intended absolute pitch without accessing outside the pitch table.

Positive pitch offsets retain their existing behavior.

## Validation

- `./mvnw.cmd clean package`
- 2 regression tests, all passing
- shaded plugin JAR generated successfully

## Related reports

[Spliterash/MusicBox#27](https://github.com/Spliterash/MusicBox/issues/27) reports choppy playback and sounds randomly cutting out with NoteBlockAPI 1.x, especially when using the extended octave range and its resource pack. This pull request fixes one concrete cause of that symptom: a negative fine-pitch value crossing an octave boundary could throw during 10-octave playback and abort the remaining notes in the current song tick.

The report also discusses broader playback timing and NoteBlockAPI 2.0 migration concerns. Those parts are separate from this pitch fix and are addressed independently by #130 or remain outside this pull request.
